### PR TITLE
Added devicejs node library

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,3 +52,11 @@ parts:
     files:
         plugin: dump
         source: files/
+    devicejs:
+      plugin: nodejs
+      nodejs-package-manager: npm
+      build-packages:
+        - python
+        - build-essential
+      source: https://github.com/mray190/devicejs-ng.git 
+      source-branch: master


### PR DESCRIPTION
Created a devicejs part using the nodejs plugin
Temporarily uses the mray190 fork instead of armpelionedge

Reasoning for mray190 fork:
socket.io version <=1.3 uses URL links during npm install
URL links were fixed for socket.io version 1.4+
Awaiting socket.io version bump to armpelionedge fork