### PR TITLE
Jenkinsfile: update package list before running snapcraft

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
                 sh '''
                     snapcraft --version
                     cp "${MBED_CLOUD_DEV_CREDENTIALS_C}" mbed_cloud_dev_credentials.c
+                    apt-get update
                     snapcraft
                     '''
             }


### PR DESCRIPTION
Jenkins builds are failing with the following error:

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/e/expat/libexpat1_2.1.0-7ubuntu0.16.04.3_amd64.deb  404  Not Found [IP: 91.189.91.26 80]

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_4.4.0-151.178_amd64.deb  404  Not Found [IP: 91.189.91.26 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?