### PR TITLE
Changed var mapping for all parts to pelion-edge

### DIFF
--- a/cmake/target.cmake
+++ b/cmake/target.cmake
@@ -3,8 +3,8 @@ SET (OS_BRAND Linux)
 SET (MBED_CLOUD_CLIENT_DEVICE x86_x64)
 SET (PAL_TARGET_DEVICE x86_x64)
 
-SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/var/lib/edge-core/mcc_config\"")
-SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/var/lib/edge-core/mcc_config\"")
+SET (PAL_FS_MOUNT_POINT_PRIMARY "\"/var/lib/pelion-edge/mcc_config\"")
+SET (PAL_FS_MOUNT_POINT_SECONDARY "\"/var/lib/pelion-edge/mcc_config\"")
 SET (PAL_USER_DEFINED_CONFIGURATION "\"${CMAKE_CURRENT_SOURCE_DIR}/config/sotp_fs_linux.h\"")
 
 if (${FIRMWARE_UPDATE})

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,14 +20,12 @@ apps:
     help:
       command: cat ${SNAP}/help.md
     deviceoswd:
-      command: wigwag/system/bin/deviceOSWD -w 3000 -m 900 -s /var/lib/pelion/deviceOSkeepalive
+      command: wigwag/system/bin/deviceOSWD -w 3000 -m 900 -s /var/lib/pelion-edge/deviceOSkeepalive
       daemon: simple 
       plugs: [network-bind]
 layout:
-    /var/lib/edge-core:
-        bind: $SNAP_DATA/var/lib/edge-core
-    /var/lib/pelion:
-        bind: $SNAP_DATA/var/lib/pelion
+    /var/lib/pelion-edge:
+        bind: $SNAP_DATA/var/lib/pelion-edge
 parts:
     edge-core:
       plugin: cmake


### PR DESCRIPTION
All files within the var directory now point to:
/var/lib/pelion-edge/

Change deviceOSWD script to access the updated websocket file
Changed edge-core to access the updated config file