### PR TITLE
use gosu to run commands as the local user inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,14 @@ RUN unsquashfs -d /snap/go/current go.snap
 # Link the go binaries to make them available to snapcraft
 RUN ln -sf /snap/go/current/bin/go /snap/bin/go
 RUN ln -sf /snap/go/current/bin/gofmt /snap/bin/gofmt
+
+# Install gosu so that we can run snapcraft as the current user
+# instead of as root
+RUN apt install gosu
+
+# Install the script that sets up the user environment
+# and runs CMD as the current user instead of as root
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Add local user that matches the $PWD owner and run command as that user
+USER_ID=$(stat -c "%u" ${PWD})
+echo "${PWD} is owned by UID ${USER_ID}.  Starting as that UID"
+useradd --shell /bin/bash -u ${USER_ID} -o -c "" -m user
+
+# Give the user sudo privileges so that snapcraft can install required packages
+usermod -aG sudo user
+echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Copy ssh keys, netrc, and other necessary config files so that snapcraft
+# can clone private repos
+cp -rf ${HOME}/.ssh /home/user/
+cp -f ${HOME}/.netrc /home/user/
+cp -f ${HOME}/.gitconfig /home/user/
+chown -R user:user /home/user/
+
+# Run the command as user
+export HOME=/home/user
+exec gosu user "$@"


### PR DESCRIPTION
when we use the docker container to run snapcraft, the build
output is owned by the root user, which causes problems for the
current user once the docker container exits.  for example,
the current user would need sudo access on the host to clean the
build output files because they are owned by root.