### PR TITLE
Added fog-proxy part

### DIFF
--- a/files-dumped/fp-edge.conf
+++ b/files-dumped/fp-edge.conf
@@ -1,0 +1,1 @@
+-proxy-uri=https://kaas-edge-nodes.arm.com -ca=/userdata/edge_gw_config/ca.pem -cert-strategy-options=cert=/userdata/edge_gw_config/kubelet.pem -cert-strategy-options=key=/userdata/edge_gw_config/kubelet-key.pem -tunnel-uri=ws://127.0.0.1:8080/connect

--- a/files-dumped/launch-fp-edge.sh
+++ b/files-dumped/launch-fp-edge.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# SNAP_DATA: /var/snap/pelion-edge/current/
+CONF_FILE=${SNAP_DATA}/fp-edge.conf
+
+# defaults
+ARGS=""
+
+# read from CLI args given by snapcraft.yaml->apps->command
+if [ "$#" -gt "0" ]; then
+    ARGS="${ARGS} $@"
+fi
+
+# read from conf file
+if [ -f "${CONF_FILE}" ]; then
+    ARGS="${ARGS} $(cat "${CONF_FILE}")"
+fi
+
+mkdir -p /userdata/edge_gw_config
+jq -r .ssl.ca.ca /userdata/edge_gw_config/identity.json > /userdata/edge_gw_config/ca.pem
+jq -r .ssl.server.certificate /userdata/edge_gw_config/identity.json > /userdata/edge_gw_config/kubelet.pem
+jq -r .ssl.server.key userdata/edge_gw_config/identity.json > /userdata/edge_gw_config/kubelet-key.pem
+exec ${SNAP}/wigwag/system/bin/fp-edge ${ARGS}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,10 @@ apps:
       command: wigwag/system/bin/maestro -config wigwag/wwrelay-utils/conf/maestro-conf/edge-config-rpi-production.yaml
       daemon: simple
       plugs: [network-bind]
+    fp-edge:
+      command: launch-fp-edge.sh
+      daemon: simple
+      plugs: [network-bind]
 layout:
     /var/lib/pelion-edge:
         bind: $SNAP_DATA/var/lib/pelion-edge
@@ -72,6 +76,20 @@ parts:
       stage: [ -deps/*, -bin/devicedb ]
       organize:
         '*': wigwag/devicejs-ng/
+    fog-proxy:
+      plugin: go
+      source: git@github.com:armPelionEdge/fog-proxy.git
+      source-branch: master
+      go-importpath: github.com/armPelionEdge/fog-proxy
+      stage-packages:
+        - jq
+      override-build: |
+        snapcraftctl build
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
+      organize:
+        bin/fp-edge: wigwag/system/bin/fp-edge
+      stage:
+        - wigwag/system/bin/fp-edge
     devicedb:
       plugin: go
       source: git@github.com:armPelionEdge/devicedb.git


### PR DESCRIPTION
Import fog-proxy, install using the go plugin
Add fp-edge (binary built) as a daemon, and pass in a conf
file to allow changing of input parameters of the daemon
during runtim instead of rebuilding the snap

Same system used for the edge-core daemon