### PR TITLE
maestro: add wigwag/system/lib to LD_LIBRARY_PATH

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,8 @@ apps:
       plugs: [network-bind]
     maestro:
       command: wigwag/system/bin/maestro -config wigwag/wwrelay-utils/conf/maestro-conf/edge-config-rpi-production.yaml
+      environment:
+        LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/wigwag/system/lib
       daemon: simple
       plugs: [network-bind]
     fp-edge:


### PR DESCRIPTION
this fixes an issue where maestro can't dynamically link to
libgrease.so