### PR TITLE
add 5s delay to maestro restart

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,8 @@ apps:
       command: wigwag/system/bin/maestro -config wigwag/wwrelay-utils/conf/maestro-conf/edge-config-rpi-production.yaml
       environment:
         LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/wigwag/system/lib
+      passthrough:
+        restart-delay: 5s
       daemon: simple
       plugs: [network-bind]
     fp-edge:


### PR DESCRIPTION
this avoids the following error message in the systemctl logs and
allows it to keep trying much longer without failing:

        "Start request repeated too quickly"