### PR TITLE
Add edgenet for use with kubelet

### DIFF
--- a/files-dumped/bin/go-build-helper.sh
+++ b/files-dumped/bin/go-build-helper.sh
@@ -1,0 +1,23 @@
+# example usage:
+# $ gopartbootstrap github.com/edgexfoundry/edgex-go
+gopartbootstrap() 
+{
+    # first set the GOPATH to be in the current directory and in ".gopath"
+    export GOPATH="$(pwd)/.gopath"
+    # setup path to include both $SNAPCRAFT_STAGE/bin and $GOPATH/bin
+    # the former is for the go tools, as well as things like glide, etc.
+    # while the later is for govendor, etc. and other go tools that might need to be installed
+    export PATH="$SNAPCRAFT_STAGE/bin:$GOPATH/bin:$PATH"
+    # set GOROOT to be whatever the go tool from SNAPCRAFT_STAGE/bin is
+    export GOROOT=$(go env GOROOT)
+    # now setup the GOPATH for this part using the import path
+    export GOIMPORTPATH="$GOPATH/src/$1"
+    mkdir -p $GOIMPORTPATH
+    # note that some tools such as govendor don't work well with symbolic links, so while it's unfortunate
+    # we have to copy all this it's a necessary evil at the moment...
+    # but note that we do ignore all files that start with "." with the "./*" pattern
+    cp -r ./* $GOIMPORTPATH
+
+    # finally go into the go import path to prepare for building
+    cd $GOIMPORTPATH
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,9 @@ apps:
         restart-delay: 5s
       daemon: simple
       plugs: [network-bind]
+    edgenet:
+      command: docker network create --subnet=10.0.0.0/24 --gateway=10.0.0.1 edgenet
+      plugs: [docker-execuutables]
     fp-edge:
       command: launch-fp-edge.sh
       daemon: simple
@@ -67,8 +70,39 @@ parts:
       organize:
         'edge-core': wigwag/mbed/
     files:
-        plugin: dump
-        source: files-dumped/
+      plugin: dump
+      source: files-dumped/
+      stage:
+        - bin/*
+        - '*'
+      prime:
+        - -bin/go-build-helper.sh
+    docker-cli:
+      after:
+        - files
+      plugin: make
+      build-snaps: ["go"]
+      source: git@github.com:docker/cli.git
+      source-tag: v18.09.7
+      override-build: |
+        # docker build specific environment variables
+        export VERSION=$SNAPCRAFT_PROJECT_VERSION
+        export DOCKER_GITCOMMIT=$(git rev-parse --short HEAD)
+        export GITCOMMIT=$DOCKER_GITCOMMIT
+        export DISABLE_WARN_OUTSIDE_CONTAINER=1
+
+        # setup the go build environment for docker-cli
+        . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
+        gopartbootstrap github.com/docker/cli
+
+        # build the docker cli binary
+        cd $GOPATH/src/github.com/docker/cli
+        unset LDFLAGS
+        make dynbinary
+
+        install -d "$SNAPCRAFT_PART_INSTALL/bin"
+        install -T "$GOPATH/src/github.com/docker/cli/build/docker" "$SNAPCRAFT_PART_INSTALL/bin/docker"
+        install -T "$GOPATH/src/github.com/docker/cli/contrib/completion/bash/docker" "$SNAPCRAFT_PART_INSTALL/bin/docker-completion.sh"
     devicejs-ng:
       plugin: nodejs-improved
       nodejs-package-manager: npm


### PR DESCRIPTION
This brings in a duplicate docker-cli module, but we can worry about
then once I find a way to run docker from the docker snap