### PR TITLE
Add service that waits for a pelion identity

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,7 +45,7 @@ apps:
       daemon: simple
       plugs: [network-bind]
     wait-for-pelion-identity:
-      command: wigwag/wwrelay-utils/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
+      command: sh wigwag/wwrelay-utils/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
       daemon: oneshot
       restart-condition: on-failure
       passthrough:


### PR DESCRIPTION
Preliously, we did not query the identity information from edge-core.
The added service queries idenety informatio from edge-core with the
same code that runs in the RPi.