### PR TITLE
Add `jq` and `curl`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -146,6 +146,23 @@ parts:
       stage:
         - etc/init.d/deviceOS-watchdog
         - wigwag/system/bin/*
+    jq:
+      plugin: autotools
+      configflags:
+        - -disable-docs
+      source: git@github.com:stedolan/jq.git
+      source-branch: jq-1.6
+      build-packages:
+        - libtool
+        - flex
+        - bison
+    curl:
+      plugin: autotools
+      source: git@github.com:curl/curl.git
+      source-branch: curl-7_65_3
+      install-via: prefix
+      build-packages:
+        - libtool
     wwrelay-utils:
       plugin: nodejs-improved
       nodejs-package-manager: npm


### PR DESCRIPTION
These packages are used by stuff in the snap and don't use up much
space after compilation.