### PR TITLE
Remove Hard Coded KAAS URL

### DIFF
--- a/files-dumped/fp-edge.conf.json
+++ b/files-dumped/fp-edge.conf.json
@@ -1,0 +1,3 @@
+{
+    "edge_proxy_uri_relative_path": "/edge-proxy/connect"
+}

--- a/files-dumped/launch-fp-edge.sh
+++ b/files-dumped/launch-fp-edge.sh
@@ -2,11 +2,12 @@
 mkdir -p ${SNAP_DATA}/userdata/edge_gw_config
 jq -r .ssl.server.certificate ${SNAP_DATA}/var/lib/edge_gw_identity/identity.json > ${SNAP_DATA}/userdata/edge_gw_config/kubelet.pem
 jq -r .ssl.server.key ${SNAP_DATA}/var/lib/edge_gw_identity/identity.json > ${SNAP_DATA}/userdata/edge_gw_config/kubelet-key.pem
-EDGE_K8S_ADDRESS=`jq -r .edgek8sServicesAddress ${SNAP_DATA}/var/lib/edge_gw_identity/identity.json`
-GATEWAYS_ADDRESS=`jq -r .gatewayServicesAddress ${SNAP_DATA}/var/lib/edge_gw_identity/identity.json`
+EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress ${SNAP_DATA}/var/lib/edge_gw_identity/identity.json)
+GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${SNAP_DATA}/var/lib/edge_gw_identity/identity.json)
+EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/fp-edge.conf.json)
 
 exec ${SNAP}/wigwag/system/bin/fp-edge \
     -proxy-uri=${EDGE_K8S_ADDRESS} \
     -cert-strategy-options=cert=${SNAP_DATA}/userdata/edge_gw_config/kubelet.pem \
     -cert-strategy-options=key=${SNAP_DATA}/userdata/edge_gw_config/kubelet-key.pem \
-    -tunnel-uri=wss://${GATEWAYS_ADDRESS#"https://"}/edge-proxy/connect
+    -tunnel-uri=wss://${GATEWAYS_ADDRESS#"https://"}$EDGE_PROXY_URI_RELATIVE_PATH

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,6 +4,10 @@ if [ ! -f "$SNAP_DATA/edge-core.conf" ]; then
     cp "$SNAP/edge-core.conf" "$SNAP_DATA/edge-core.conf"
 fi
 
+if [ ! -f "$SNAP_DATA/fp-edge.conf.json" ]; then
+    cp "$SNAP/fp-edge.conf.json" "$SNAP_DATA/fp-edge.conf.json"
+fi
+
 if [ ! -d "$SNAP_DATA/userdata/etc" ]; then
     mkdir -p $SNAP_DATA/userdata/etc
 fi


### PR DESCRIPTION
This PR pulls the URLs for edge-k8s and gateway domains from the system configuration instead of using a hard-coded string that pointed to the KAAS sandbox.