### PR TITLE
Fix post-refresh hook

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,3 +1,5 @@
+#!/bin/bash -e
+
 # Copyright (c) 2016 Canonical Ltd.
 
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -18,8 +20,6 @@
 # CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-#!/bin/bash -e
 
 # copy the config file from $SNAP into $SNAP_DATA if it doesn't exist
 if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then


### PR DESCRIPTION
The shebang (#!) must be the first two characters of a file in order
to be correctly interpreted by the kernel.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>