### PR TITLE
Add ssh key passphrase warning

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,9 @@ cp -f ${HOME}/.netrc /home/user/
 cp -f ${HOME}/.gitconfig /home/user/
 chown -R user:user /home/user/
 
+# Issue a warning if the ssh key has a password
+ssh-keygen -y -P "" -f ${HOME}/.ssh/id_rsa >/dev/null
+
 # Run the command as user
 export HOME=/home/user
 exec gosu user "$@"


### PR DESCRIPTION
This will issue a warning if the supplied ssh key has a passphrase,
since the default setup can't build with such a key and the failure
message isn't obvious.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>