### PR TITLE
README: Change supported OS to Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains snapcraft packaging for Pelion Edge. This lets you run 
 
 ### Build prerequisites
 
-- any OS which supports Docker
+- a Linux box with Docker configured (other operating systems may work but aren't supported)
 - git
 
 ### User account prerequisites


### PR DESCRIPTION
We ran into npm I/O errors when testing under MacOS and decided to
clarify the supported OS choices. (This is not a change in scope, as
we've only supported Linux until now anyway).

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>