### PR TITLE
edge-core-reset-storage should start edge-core daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ After the snap is installed, Pelion Edge starts automatically:
 - To reset your local Pelion Cloud credentials, stop Pelion Edge, and run `pelion-edge.edge-core-reset-storage`:
 
     ```bash
-    snap stop pelion-edge
-    pelion-edge.edge-core-reset-storage
+    snap stop pelion-edge.edge-core
+    snap start pelion-edge.edge-core-reset-storage
     ```
 
 These are just convenient snap commands that run the binaries. The actual binaries are at `/snap/pelion-edge/current/`. Use the [Pelion Edge docs](https://github.com/armpelionedge/snap-pelion-edge#general-info-for-running-the-binaries) for information about running the binaries directly.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,11 @@ apps:
       plugs: [hardware-observe, network-bind, network-control, network-observe, system-files]
     edge-core-reset-storage:
       command: launch-edge-core.sh --reset-storage
+      passthrough:
+        restart-delay: 5s
+      restart-condition: always
+      daemon: simple
+      plugs: [hardware-observe, network-bind, network-control, network-observe, system-files]
     help:
       command: cat ${SNAP}/help.md
     deviceoswd:


### PR DESCRIPTION
the expectation for calling edge-core with --reset-storage
option is that storage is cleared *and* edge-core is started.