### PR TITLE
disable maestro auto start

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,10 +55,6 @@ apps:
       command: wigwag/system/bin/maestro -config $SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml
       environment:
         LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/wigwag/system/lib
-      passthrough:
-        restart-delay: 5s
-      restart-condition: always
-      daemon: simple
       plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, netlink-audit, netlink-connector, network-bind, network-control, network-observe, system-files, x11]
     edgenet:
       command: launch-edgenet.sh


### PR DESCRIPTION
maestro has some critical stability issues and is not absolutely
required for LA release anyway.  after some internal discussion
with stakeholders, it was decided to disable maestro temporarily
for LA release.

maestro is to be fixed and re-enabled for GA release.