### PR TITLE
disable edge-core-reset-storage service by default

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -36,3 +36,8 @@ mkdir -p "$SNAP_DATA/etc/docker"
 if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
     cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo-no-dhcp.yaml" "$SNAP_DATA/maestro-config.yaml"
 fi
+
+# disable auto-start on some services.
+# as of snapcraft v3.8, services can't be configured to be disabled by default
+# in snapcraft.yaml and must instead be disabled in the install hook.
+snapctl stop --disable pelion-edge.edge-core-reset-storage


### PR DESCRIPTION
in a previous commit, edge-core-reset-storage was changed from an
app to a service due to feedback from users that the reset-storage
variant should still result in a running daemon. however, the change
resulted in 2 instances of edge-core running after installation, one
with the reset-storage option and one without.

in snapcraft, the "daemon: simple" flag is used to specify that a
command should be run as a service, but there are no provisions
in snapcraft.yaml to specify that the service should not be enabled
by default.  instead, the recommended approach from [1] is to disable
the service in the snapcraft install hook, followed in this commit.

[1] https://forum.snapcraft.io/t/disable-service-by-default/14349/4