### PR TITLE
remove edgenet as a service

### DIFF
--- a/files-dumped/launch-kubelet.sh
+++ b/files-dumped/launch-kubelet.sh
@@ -1,10 +1,14 @@
 
 DEVICE_ID=`jq -r .deviceID ${SNAP_DATA}/var/lib/edge_gw_identity/identity.json`
-
 if [ $? -ne 0 ]; then
     echo "Unable to extract device ID from identity.json"
-
     exit 1
+fi
+
+${SNAP}/launch-edgenet.sh
+if [ $? -ne 0 ]; then
+    echo "Unable to create edgenet docker network"
+    exit 2
 fi
 
 exec ${SNAP}/wigwag/system/bin/kubelet \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,13 +61,6 @@ apps:
       restart-condition: always
       daemon: simple
       plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, netlink-audit, netlink-connector, network-bind, network-control, network-observe, system-files, x11]
-    edgenet:
-      command: launch-edgenet.sh
-      daemon: simple
-      restart-condition: on-failure
-      passthrough:
-        restart-delay: 5s
-      plugs: [docker]
     fp-edge:
       passthrough:
         restart-delay: 5s
@@ -81,6 +74,7 @@ apps:
     kubelet:
       passthrough:
         restart-delay: 5s
+        after: [dockerd]
       restart-condition: always
       command: launch-kubelet.sh
       daemon: simple


### PR DESCRIPTION
the kubelet service requires the edgenet docker network to be defined,
but the mechanism used to set up edgenet can be simplified by having
the kubelet startup script be responsible for creating the network,
rather than treating "edgenet" as its own service.

this clears up some confusion about edgenet showing up as an inactive
service when viewing pelion-edge service statuses, since really it's
just a config requirement.