### PR TITLE
add wwrelay-utils conf files removed by previous commit

### DIFF
--- a/scripts/install_check.sh
+++ b/scripts/install_check.sh
@@ -12,6 +12,7 @@ declare -a file_list=(
     'wigwag/system'
     'wigwag/system/bin'
     'wigwag/system/lib'
+    'wigwag/wwrelay-utils/conf'
     'wigwag/wwrelay-utils/debug_scripts'
     'etc/init.d/maestro.sh'
     'wigwag/etc/versions.json'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -192,6 +192,7 @@ parts:
         node_modules: wigwag/devicejs-core-modules/node_modules
         debug_scripts: wigwag/wwrelay-utils/debug_scripts
         bin: wigwag/system/bin
+        conf: wigwag/wwrelay-utils/conf
       filesets:
         versions:
           - wigwag/etc/versions.json
@@ -200,10 +201,13 @@ parts:
         production:
           - wigwag/wwrelay-utils/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
           - wigwag/system/bin/
+        conf:
+          - wigwag/wwrelay-utils/conf
       prime:
         - $versions
         - $node_modules
         - $production
+        - $conf
     dss:
       plugin: dump
       source: https://github.com/armPelionEdge/edgeos-shell-scripts.git


### PR DESCRIPTION
maestro was disabled in the release, so the conf files weren't
needed there, but we do need the conf files in dev so that
maestro can be debugged.