### PR TITLE
remove redundant git submodule update step

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -130,7 +130,6 @@ parts:
         - git
       override-pull: |
         snapcraftctl pull
-        git submodule update --init --recursive
         cp ${SNAPCRAFT_PROJECT_DIR}/mbed_cloud_dev_credentials.c config/mbed_cloud_dev_credentials.c
         cp ${SNAPCRAFT_PROJECT_DIR}/cmake/target.cmake config/target.cmake
         cp ${SNAPCRAFT_PART_SRC}/cmake/toolchains/mcc-linux-x86.cmake config/toolchain.cmake


### PR DESCRIPTION
* snapcraftctl-pull handles this already

https://github.com/snapcore/snapcraft/blob/master/snapcraft/internal/sources/_git.py#L196