### PR TITLE
Upgrade edge-core release to latest 0.12.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -123,7 +123,7 @@ parts:
     edge-core:
       plugin: cmake
       source: https://github.com/ARMmbed/mbed-edge.git
-      source-tag: 0.9.0
+      source-tag: 0.12.0
       build-packages:
         - build-essential
         - cmake


### PR DESCRIPTION
HW-LA was released with edge-core 0.9.0, which is 3 release behind.
We should now use and test with latest and greatest of edge-core which is
0.12.0