### PR TITLE
Add a factory reset script to edge-core

### DIFF
--- a/files-dumped/edge-core-factory-reset
+++ b/files-dumped/edge-core-factory-reset
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# This is present on some, but not all gateways, and is where logs are persisted.
+rm -f /var/log/syslog*

--- a/files-dumped/launch-edge-core.sh
+++ b/files-dumped/launch-edge-core.sh
@@ -16,4 +16,5 @@ if [ -f "${CONF_FILE}" ]; then
     ARGS="${ARGS} $(cat "${CONF_FILE}")"
 fi
 
-exec ${SNAP}/wigwag/mbed/edge-core ${ARGS}
+# add ${SNAP} to PATH edge-core can run the factory reset script: edge-core-factory-reset
+exec env PATH=${PATH}:${SNAP} ${SNAP}/wigwag/mbed/edge-core ${ARGS}


### PR DESCRIPTION
This script runs when a user executes lwm2m resource /3/0/5 - factory
reset.  Currently it removes persistent logs from the disk.

Calling this script on factory reset will depend on an edge-core change.