### PR TITLE
Change default edge-core build from dev to factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,24 @@ This repository contains snapcraft packaging for Pelion Edge. This lets you run 
     git clone https://github.com/armpelionedge/snap-pelion-edge
     cd snap-pelion-edge
     ```
+1. Setup Device certificates:
+ 
+	Currently the build is configured for factory provisioning.  Documentation on the choices for certificate configuration modes can be found at [Configuring Edge Build](https://github.com/ARMmbed/mbed-edge#configuring-edge-build) .
 
-1. Generate a device certificate from the Device Management Portal:
+	If you wish to configure for developer mode:
+   1. Change the definitions of DEVELOPER_MODE and FACTORY_MODE in `snap/snapcraft.yaml` to DEVELOPER_MODE=ON and FACTORY_MODE=OFF
+   1. Generate a device certificate from the Device Management Portal:
    
-   1. Log in to the [Device Management Portal](https://portal.mbedcloud.com/login), and select **Device identity > Certificates**.
-   1. If you don't have a certificate, select **New certificate > Create a developer certificate**.
-   1. When you have a certificate, and open its panel.
-   1. On this panel, click **Download Developer C file** to receive `mbed_cloud_dev_credentials.c`.
+      1. Log in to the [Device Management Portal](https://portal.mbedcloud.com/login), and select **Device identity > Certificates**.
+      1. If you don't have a certificate, select **New certificate > Create a developer certificate**.
+      1. When you have a certificate, and open its panel.
+      1. On this panel, click **Download Developer C file** to receive `mbed_cloud_dev_credentials.c`.
 
-1. Copy `mbed_cloud_dev_credentials.c` to the `snap-pelion-edge` directory:
+   1. Copy `mbed_cloud_dev_credentials.c` to the `snap-pelion-edge` directory:
 
-    ```bash
-    cp /path/to/mbed_cloud_dev_credentials.c /path/to/snap-pelion-edge/.
-    ```
+        ```bash
+        cp /path/to/mbed_cloud_dev_credentials.c /path/to/snap-pelion-edge/.
+        ```
 
 1. Make sure your `~/.ssh/id_rsa.pub` key is registered with `github.com` and `gitlab.com`, and that they both exist in `known_hosts` (for example, by running `ssh -T git@github.com` and `ssh -T git@gitlab.com`).
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -126,7 +126,9 @@ parts:
         - git
       override-pull: |
         snapcraftctl pull
-        cp ${SNAPCRAFT_PROJECT_DIR}/mbed_cloud_dev_credentials.c config/mbed_cloud_dev_credentials.c
+        # mbed_cloud_dev_credentials.c should only exist if DEVELOPER_MODE=ON below
+        # Piping to true allows the cp to not fail when the file is not present
+        cp ${SNAPCRAFT_PROJECT_DIR}/mbed_cloud_dev_credentials.c config/mbed_cloud_dev_credentials.c | true
         cp ${SNAPCRAFT_PROJECT_DIR}/cmake/target.cmake config/target.cmake
         cp ${SNAPCRAFT_PART_SRC}/cmake/toolchains/mcc-linux-x86.cmake config/toolchain.cmake
         sed -i 's!/dev/random!/dev/urandom!' lib/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/Board_Specific/TARGET_x86_x64/pal_plat_x86_x64.c
@@ -136,8 +138,8 @@ parts:
         - -DCMAKE_BUILD_TYPE=Release
         - -DTRACE_LEVEL=INFO
         - -DFIRMWARE_UPDATE=OFF
-        - -DDEVELOPER_MODE=ON
-        - -DFACTORY_MODE=OFF
+        - -DDEVELOPER_MODE=OFF
+        - -DFACTORY_MODE=ON
         - -DBYOC_MODE=OFF
         - -DTARGET_CONFIG_ROOT=${SNAPCRAFT_PART_SRC}/config
       override-build: |


### PR DESCRIPTION
Changed the defines of DEVELOPER_MODE and FACTORY_MODE in
snapcraft.yaml.  Additionally removed the requirement for the
existence of mbed_dev_credentials.c

Signed-off-by: Kyle Stein <kyle.stein@arm.com>