### PR TITLE
Add a fake bootloader to edge-core

### DIFF
--- a/files-dumped/edge-core-bootloader.sh
+++ b/files-dumped/edge-core-bootloader.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script is used for firmware upgrades.  It checks for the existence of an
+# upgrade.tar.gz file in ${SNAP_DATA}/upgrades/, and if found, untars the file
+# and runs the runme.sh script inside.
+
+# SNAP_DATA: /var/snap/pelion-edge/current/
+# path copied from snap-pelion-edge/snap/hooks/install
+UPGRADE_DIR=${SNAP_DATA}/upgrades
+UPGRADE_TGZ=${UPGRADE_DIR}/upgrade.tar.gz
+UPGRADE_WORKDIR=/tmp/pelion-edge-upgrade/
+
+echo "Checking for ${UPGRADE_TGZ}"
+if [ -e "${UPGRADE_TGZ}" ]; then
+	#TODO: verify the firmware tarball signature & integrity
+	mkdir -p "${UPGRADE_WORKDIR}"
+	tar -xzf "${UPGRADE_TGZ}" -C "${UPGRADE_WORKDIR}"
+	pushd "${UPGRADE_WORKDIR}"
+	if [ -x runme.sh ]; then
+		./runme.sh
+	else
+		echo "ERROR: upgrade.tar.gz did not contain runme.sh"
+	fi
+	popd
+	# remove the file so that we don't fall into an upgrade loop
+	rm "${UPGRADE_TGZ}"
+	rm -rf "${UPGRADE_WORKDIR}"
+fi

--- a/files-dumped/launch-edge-core.sh
+++ b/files-dumped/launch-edge-core.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# before we do anything, call the fake bootloader
+./edge-core-bootloader.sh
+
 # SNAP_DATA: /var/snap/pelion-edge/current/
 CONF_FILE=${SNAP_DATA}/edge-core.conf
 


### PR DESCRIPTION
The fake bootloader is just a script that runs before edge-core
and checks for the existence of upgrade files.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>