### PR TITLE
Switch default mode FROM production TO developer

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -146,8 +146,8 @@ parts:
         - -DCMAKE_BUILD_TYPE=Release
         - -DTRACE_LEVEL=INFO
         - -DFIRMWARE_UPDATE=OFF
-        - -DDEVELOPER_MODE=OFF
-        - -DFACTORY_MODE=ON
+        - -DDEVELOPER_MODE=ON
+        - -DFACTORY_MODE=OFF
         - -DBYOC_MODE=OFF
         - -DTARGET_CONFIG_ROOT=${SNAPCRAFT_PART_SRC}/config
       override-build: |


### PR DESCRIPTION
Still leave ability to use production mode, but manual switches will be required.

Details already in README