### PR TITLE
PELEDGE19-1475: fixed certificate renewal defect for fog-proxy

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,7 +166,7 @@ parts:
     fog-proxy:
       plugin: go
       source: git@github.com:armPelionEdge/fog-proxy.git
-      source-commit: ae0e1a185dbacbc3b3c937161ce24b64b023433a
+      source-commit: 8e5cd30b070c6ad7d5696a7d1a5a00a11d258681
       go-importpath: github.com/armPelionEdge/fog-proxy
       override-build: |
         snapcraftctl build


### PR DESCRIPTION
Update:
* Fixed the defect that fog-proxy stops working after device certificate renewal by relaunching proxy server with updated device certs
* Fixed the bug that fog-proxy actually doesn't work properly if edge-core goes away while fog-proxy is still connecting to, since while fog-proxy tries to reconnect to edge-core but the WebSocket connection hasn't been registered as protocol translator again.

