### PR TITLE
Add default platform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ $ tar -tzf firmware-update.tar.gz
     * For example, add instructions to run `snap install` on each snap you intend to update
 1. Modify the example update/platform_version with the new version and copy it into the update folder
     * Note the version should be a single string that encompasses all software packages being managed by this firmware update mechanism, and not necessarily limited to the version of the Pelion Edge snap itself.
+    * The initial platform version (used by a system that has never been updated) is taken at build time from the `update/platform_version` file in this repo.
 1. Create the firmware update package tar.gz from the contents of the update folder, which must contain at least the upgrade script `runme.sh` and the new version file `platform_version`, and optionally any updated software packages.
 	```bash
 	tar -czf firmware-update.tar.gz -C update/ .

--- a/files-dumped/edge-core-bootloader.sh
+++ b/files-dumped/edge-core-bootloader.sh
@@ -6,8 +6,8 @@
 
 # SNAP_DATA: /var/snap/pelion-edge/current/
 # path copied from snap-pelion-edge/snap/hooks/install
-UPGRADE_DIR=${SNAP_DATA}/upgrades
-UPGRADE_TGZ=${UPGRADE_DIR}/upgrade.tar.gz
+UPGRADE_DIR="${SNAP_DATA}/upgrades"
+UPGRADE_TGZ="${UPGRADE_DIR}/upgrade.tar.gz"
 UPGRADE_WORKDIR=/tmp/pelion-edge-upgrade/
 
 echo "Checking for ${UPGRADE_TGZ}"
@@ -26,3 +26,4 @@ if [ -e "${UPGRADE_TGZ}" ]; then
 	rm "${UPGRADE_TGZ}"
 	rm -rf "${UPGRADE_WORKDIR}"
 fi
+echo "Platform version is $(cat ${SNAP_DATA}/etc/platform_version)"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -37,6 +37,11 @@ if [ ! -f "$SNAP_DATA/maestro-config.yaml" ]; then
     cp "$SNAP/wigwag/wwrelay-utils/conf/maestro-conf/edge-config-dell5000-demo.yaml" "$SNAP_DATA/maestro-config.yaml"
 fi
 
+if [ ! -f "$SNAP_DATA/etc/platform_version" ]; then
+    mkdir -p "$SNAP_DATA/etc"
+    cp "$SNAP/platform_version" "$SNAP_DATA/etc/"
+fi
+
 # disable auto-start on some services.
 # as of snapcraft v3.8, services can't be configured to be disabled by default
 # in snapcraft.yaml and must instead be disabled in the install hook.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -153,6 +153,7 @@ parts:
       override-build: |
         snapcraftctl build
         install bin/edge-core ${SNAPCRAFT_PART_INSTALL}
+        install ${SNAPCRAFT_PROJECT_DIR}/update/platform_version ${SNAPCRAFT_PART_INSTALL}
       organize:
         'edge-core': wigwag/mbed/
     files:


### PR DESCRIPTION
Provide a default platform version for the Pelion registration, in
case no version override has yet been done by FOTA.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>