### PR TITLE
Allow edge-core to read a firmware version from a file

### DIFF
--- a/files-installed/0001-Read-platform-version-file-into-LWM2M-resource-10252.patch
+++ b/files-installed/0001-Read-platform-version-file-into-LWM2M-resource-10252.patch
@@ -1,0 +1,52 @@
+From 0f724ab5a39ed59ee4980e9fec0a9b91c483df98 Mon Sep 17 00:00:00 2001
+From: Michael Ray <mjray@umich.edu>
+Date: Wed, 25 Mar 2020 14:20:17 -0500
+Subject: [PATCH] Read platform version file into LWM2M resource /10252/0/6
+
+Check for a file specified in macro PLATFORM_VERSION_FILE
+If macro PLATFORM_VERSION_FILE is not found, use /etc/platform_version file
+
+If the file does not exist at all, version becomes -1 which was default
+before this change
+---
+ .../lwm2m-mbed/source/FirmwareUpdateResource.cpp        | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp b/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
+index 1f50abd..4c45c04 100644
+--- a/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
++++ b/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
+@@ -49,6 +49,10 @@
+ #define RESOURCE_VALUE(arg) #arg
+ #endif
+ 
++#ifndef PLATFORM_VERSION_FILE
++#define PLATFORM_VERSION_FILE "/etc/platform_version"
++#endif
++
+ namespace FirmwareUpdateResource {
+ 
+ /* send delayed response */
+@@ -209,6 +213,19 @@ void FirmwareUpdateResource::Initialize(void)
+                 resourceVersion = updateInstance->create_dynamic_resource(
+                                       RESOURCE_VALUE(6), "PkgVersion", M2MResourceInstance::STRING, true);
+                 if (resourceVersion) {
++                    FILE *fp = fopen(PLATFORM_VERSION_FILE, "r");
++                    if (fp) {
++                        char buffer[32] = "missingnewline";
++                        /* Newline required at end of file for fgets to read
++                           Strip out the new line since we don't want it in the LWM2M object */
++                        if (fgets(buffer, sizeof(buffer), fp) && buffer[strlen(buffer) - 1] == '\n') {
++                            buffer[strlen(buffer)-1] = 0;
++                        }
++                        resourceVersion->set_value((uint8_t*)buffer, strlen(buffer));
++                        fclose(fp);
++                    } else {
++                        resourceVersion->set_value(defaultVersion, sizeof(defaultVersion) - 1);
++                    }
+                     resourceVersion->set_operation(M2MBase::GET_ALLOWED);
+                     resourceVersion->set_value(defaultVersion, sizeof(defaultVersion) - 1);
+                     resourceVersion->publish_value_in_registration_msg(true);
+-- 
+2.10.1.windows.1
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,6 +142,7 @@ parts:
         sed -i 's!/dev/random!/dev/urandom!' lib/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/Board_Specific/TARGET_x86_x64/pal_plat_x86_x64.c
         sed -i 's!\(MBED_CLOUD_CLIENT_LIFETIME\).*!\1 600!' config/mbed_cloud_client_user_config.h
         sed -i 's!\(MAX_RECONNECT_TIMEOUT\).*!\1 60!' lib/mbed-cloud-client/mbed-client/mbed-client/m2mconstants.h
+        git am ${SNAPCRAFT_PROJECT_DIR}/files-installed/0001-Read-platform-version-file-into-LWM2M-resource-10252.patch
       configflags:
         - -DCMAKE_BUILD_TYPE=Release
         - -DTRACE_LEVEL=INFO


### PR DESCRIPTION
Note: Future commit needed to set the actual path of the platform version file
within the snap