### PR TITLE
Revert "PELEDGE19-1481: fixed certificate renewal defect for fog-proxy"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -167,7 +167,7 @@ parts:
     fog-proxy:
       plugin: go
       source: git@github.com:armPelionEdge/fog-proxy.git
-      source-commit: 8e5cd30b070c6ad7d5696a7d1a5a00a11d258681
+      source-commit: ae0e1a185dbacbc3b3c937161ce24b64b023433a
       go-importpath: github.com/armPelionEdge/fog-proxy
       override-build: |
         snapcraftctl build


### PR DESCRIPTION
This reverts commit dff3cb632402e218be9316a5c07448d67b27821e.