### PR TITLE
Update the fp-edge launch script

### DIFF
--- a/files-dumped/launch-fp-edge.sh
+++ b/files-dumped/launch-fp-edge.sh
@@ -5,7 +5,7 @@ EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/
 
 exec ${SNAP}/wigwag/system/bin/fp-edge \
     -proxy-uri=${EDGE_K8S_ADDRESS} \
-    -tunnel-uri=wss://${GATEWAYS_ADDRESS#"https://"}$EDGE_PROXY_URI_RELATIVE_PATH \
+    -tunnel-uri=ws://${GATEWAYS_ADDRESS#"https://"}$EDGE_PROXY_URI_RELATIVE_PATH \
     -cert-strategy=tpm \
     -cert-strategy-options=socket=/tmp/edge.sock \
     -cert-strategy-options=path=/1/pt \


### PR DESCRIPTION
PR #105 has been fixed a few defects of fog-proxy. Check [this](https://github.com/armPelionEdge/snap-pelion-edge/pull/105#issue-393211759) out.

While the fix requires the tunnel service of fog-proxy goes through local proxy server only so the new tunnel uri should be `ws://` instead of `wss://` since we don't need to enable tls config for websocket connection for tunnel service anymore. 