### PR TITLE
Revert "Revert "PELEDGE19-1481: fixed certificate renewal defect for …

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -171,7 +171,7 @@ parts:
     fog-proxy:
       plugin: go
       source: git@github.com:armPelionEdge/fog-proxy.git
-      source-commit: ae0e1a185dbacbc3b3c937161ce24b64b023433a
+      source-commit: 8e5cd30b070c6ad7d5696a7d1a5a00a11d258681
       go-importpath: github.com/armPelionEdge/fog-proxy
       override-build: |
         snapcraftctl build


### PR DESCRIPTION
…fog-proxy" (#116)"

This reverts commit 797b684497fc18f8960a0517cabe13a73a143367.

Now that the fp-edge startup script is configured for ws://, we need to
use the corresponding version of fog-proxy.