### PR TITLE
Factory Reset Patch

### DIFF
--- a/files/edge-core/patches/0001-PELEDGE19-1193-Call-a-script-on-factory-reset.patch
+++ b/files/edge-core/patches/0001-PELEDGE19-1193-Call-a-script-on-factory-reset.patch
@@ -1,0 +1,43 @@
+From 08ba27962caf655a9ad94042da029bfb7c7adae0 Mon Sep 17 00:00:00 2001
+From: Kyle Stein <kyle.stein@arm.com>
+Date: Wed, 25 Mar 2020 09:14:14 -0500
+Subject: [PATCH] PELEDGE19-1193: Call a script on factory reset
+
+    Add a hook to a script on factory reset.  This gives us a chance to delete persistent customer logs from the gateway.
+
+Signed-off-by: Kyle Stein <kyle.stein@arm.com>
+---
+ edge-core/edge_server_customer_code.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/edge-core/edge_server_customer_code.c b/edge-core/edge_server_customer_code.c
+index 4ab25a0..bdc3908 100644
+--- a/edge-core/edge_server_customer_code.c
++++ b/edge-core/edge_server_customer_code.c
+@@ -21,6 +21,7 @@
+ #include "edge-client/edge_client.h"
+ #include "mbed-trace/mbed_trace.h"
+ #include "edge-core/edge_server_customer_code.h"
++#include <stdlib.h>
+ #define TRACE_GROUP "escstmr"
+ 
+ bool edgeserver_execute_rfs_customer_code(edgeclient_request_context_t *request_ctx)
+@@ -29,6 +30,15 @@ bool edgeserver_execute_rfs_customer_code(edgeclient_request_context_t *request_
+             request_ctx->object_id,
+             request_ctx->object_instance_id,
+             request_ctx->resource_id);
++
++    // Execute a script to do factory reset tasks, such as clearing customer logs.
++    int rc = system("edge-core-factory-reset");
++
++    if (rc) {
++        tr_warn("edge-core-factory-reset exited with non-success return code %d", rc);
++        return false;
++    }
++
+     return true;
+ }
+ 
+-- 
+2.14.3
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -151,6 +151,7 @@ parts:
         sed -i 's!/dev/random!/dev/urandom!' lib/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/Board_Specific/TARGET_x86_x64/pal_plat_x86_x64.c
         sed -i 's!\(MAX_RECONNECT_TIMEOUT\).*!\1 60!' lib/mbed-cloud-client/mbed-client/mbed-client/m2mconstants.h
         git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-Read-platform-version-file-into-LWM2M-resource-10252.patch
+        git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-PELEDGE19-1193-Call-a-script-on-factory-reset.patch
       configflags:
         - -DCMAKE_BUILD_TYPE=Debug
         - -DTRACE_LEVEL=DEBUG


### PR DESCRIPTION
Add patch for mbed-edge to call script on factory reset.  This patch can
be removed when the corresponding PR is merged into mbed-edge.

Signed-off-by: Kyle Stein <kyle.stein@arm.com>