### PR TITLE
Update edge-utils to fix random identity failure

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -192,7 +192,7 @@ parts:
       plugin: nodejs-improved
       nodejs-package-manager: npm
       source: https://github.com/armPelionEdge/edge-utils.git
-      source-commit: 54fac76dc9d913551b813f172716d5dfab7f2b61
+      source-commit: b0ae52b99fb8b777e0bb7512ca7e868ba0dd84a3
       override-pull: |
         snapcraftctl pull
         cp ${SNAPCRAFT_PROJECT_DIR}/files/wwrelay-utils/package.json .


### PR DESCRIPTION
Sometimes on the first install of snap pelion-edge the identity service will exit without creating an identity. This is because a bug in the identity generation script, create-new-eeprom-with-self-signed-certs.sh, erroneously returns an exit code of success (0) even though the identity was not generated.

This patch pulls in an updated version of edge-utils which has a fix for this problem:
https://github.com/armPelionEdge/edge-utils/pull/21