### PR TITLE
Update openssl download url

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -231,7 +231,7 @@ parts:
     openssl10:
       plugin: make
       make-install-var: "INSTALL_PREFIX"
-      source: https://www.openssl.org/source/openssl-1.0.2s.tar.gz
+      source: https://www.openssl.org/source/old/1.0.2/openssl-1.0.2s.tar.gz
       source-checksum: md5/98ec4e085962689b91d25e1dcdfc14a2
       override-build: |
         ./config shared


### PR DESCRIPTION
Openssl changed download urls in their web site. Here is new url for package.