### PR TITLE
bump version of openssl to 1.0.2u

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -231,8 +231,8 @@ parts:
     openssl10:
       plugin: make
       make-install-var: "INSTALL_PREFIX"
-      source: https://www.openssl.org/source/old/1.0.2/openssl-1.0.2s.tar.gz
-      source-checksum: md5/98ec4e085962689b91d25e1dcdfc14a2
+      source: https://github.com/openssl/openssl/archive/OpenSSL_1_0_2u.tar.gz
+      source-checksum: md5/c38577624507dad3a4a1f3d07b84fa59
       override-build: |
         ./config shared
         make depend


### PR DESCRIPTION
keep up to date with the latest major verison of openssl
with which our code is compatible.