### PR TITLE
On Factory Reset, remove identity.json

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -3,6 +3,8 @@
 # This is present on some, but not all gateways, and is where logs are persisted.
 rm -f /var/log/syslog*
 
+rm -f ${SNAP_DATA}/userdata/edge_gw_identity/identity.json
+
 # Stop and remove all existing docker containers and images
 docker stop $(docker ps -a -q) || true
 docker system prune --volumes -a -f || true


### PR DESCRIPTION
This file is generated from edge-core credentials.  On factory reset, this file's contents are no longer valid.