### PR TITLE
add fog-proxy patch

### DIFF
--- a/files/fog-proxy/patches/0001-HACK-wait-for-the-rpc-client-to-call-PT-Register.patch
+++ b/files/fog-proxy/patches/0001-HACK-wait-for-the-rpc-client-to-call-PT-Register.patch
@@ -1,0 +1,30 @@
+From dc1feaa5b3827ad6120f8b1544b5c4fbfea800a0 Mon Sep 17 00:00:00 2001
+From: Nic Costa <nic.costa@gmail.com>
+Date: Fri, 17 Apr 2020 15:46:08 -0500
+Subject: [PATCH] HACK: wait for the rpc client to call PT Register
+
+Async RPC calls won't receive replies from edge-core if the
+client hasn't first completed pt registration.
+---
+ tls/tpm.go | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/tls/tpm.go b/tls/tpm.go
+index 5768bb8..cb2aa14 100644
+--- a/tls/tpm.go
++++ b/tls/tpm.go
+@@ -185,7 +185,10 @@ func newJSONRPCClient(socket string, path string) *rpc.Client {
+ 		return nil
+ 	}
+ 
+-	return rpc.Dial(socket, path, onConn)
++	client := rpc.Dial(socket, path, onConn)
++	fmt.Printf("HACK: sleeping for 5 seconds while the client registers")
++	time.Sleep(5 * time.Second)
++	return client
+ }
+ 
+ func (pk *ecdsaPrivateKey) Public() crypto.PublicKey {
+-- 
+2.17.1
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -187,6 +187,9 @@ parts:
       source: git@github.com:armPelionEdge/fog-proxy.git
       source-commit: 8e5cd30b070c6ad7d5696a7d1a5a00a11d258681
       go-importpath: github.com/armPelionEdge/fog-proxy
+      override-pull: |
+        snapcraftctl pull
+        git am ${SNAPCRAFT_PROJECT_DIR}/files/fog-proxy/patches/0001-HACK-wait-for-the-rpc-client-to-call-PT-Register.patch
       override-build: |
         snapcraftctl build
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin


### PR DESCRIPTION
this hack forces fog-proxy to call protocol_translator_register before
calling any other RPC methods, in particular crypto_get_certificate,
because edge-core won't respond to async RPC methods coming from
protocol translators that aren't yet registered.