### PR TITLE
Turn Maestro back on

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,6 +60,11 @@ apps:
       restart-condition: always
       daemon: simple
       plugs: [account-control, bluetooth-control, firewall-control, hardware-observe, log-observe, netlink-audit, netlink-connector, network-bind, network-control, network-observe, system-files, x11]
+    maestro-shell:
+      command: wigwag/system/bin/maestro-shell
+      environment:
+        LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/wigwag/system/lib
+      plugs: [network-bind, network-control, network-observe, system-files]
     fp-edge:
       passthrough:
         restart-delay: 5s


### PR DESCRIPTION
* Re-enable maestro daemon
* Disable the PID check for devicedb to start connection attempts
* Update maestro config
* Allow maestro-shell calls from the terminal