### PR TITLE
Stop kubelet on factory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -4,6 +4,7 @@
 rm -f /var/log/syslog*
 
 rm -f ${SNAP_DATA}/userdata/edge_gw_identity/identity.json
+snap stop pelion-edge.kubelet || true
 
 # Stop and remove all existing docker containers and images
 docker stop $(docker ps -a -q) || true


### PR DESCRIPTION
If kubelet is running, kubernetes will restart any deleted containers.
We stop kubelet on factory reset so customer containers will be removed
permenantly on factory reset.