### PR TITLE
PELEDGE19-1428: add forwarding addresses feature to fog-proxy

### DIFF
--- a/files/fog-proxy/scripts/launch-fp-edge.sh
+++ b/files/fog-proxy/scripts/launch-fp-edge.sh
@@ -2,12 +2,13 @@
 EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/fp-edge.conf.json)
-
 exec ${SNAP}/wigwag/system/bin/fp-edge \
     -proxy-uri=${EDGE_K8S_ADDRESS} \
-    -tunnel-uri=ws://${GATEWAYS_ADDRESS#"https://"}$EDGE_PROXY_URI_RELATIVE_PATH \
+    -tunnel-uri=ws://gateways.local$EDGE_PROXY_URI_RELATIVE_PATH \
     -cert-strategy=tpm \
     -cert-strategy-options=socket=/tmp/edge.sock \
     -cert-strategy-options=path=/1/pt \
     -cert-strategy-options=device-cert-name=mbed.LwM2MDeviceCert \
-    -cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey
+    -cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey \
+    -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}
+ls

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -185,7 +185,7 @@ parts:
     fog-proxy:
       plugin: go
       source: git@github.com:armPelionEdge/fog-proxy.git
-      source-commit: 8e5cd30b070c6ad7d5696a7d1a5a00a11d258681
+      source-commit: e21961c5ead59ae24ca813484e8967bcb74d889c
       go-importpath: github.com/armPelionEdge/fog-proxy
       override-pull: |
         snapcraftctl pull


### PR DESCRIPTION
[PELEDGE19-1428](https://jira.arm.com/browse/PELEDGE19-1428): add forwarding addresses feature for fog-proxy so maestro, relay-term and devicedb could talk to fog-proxy later on. Requests from the other components would be proxied by fog-proxy to the target hose based on the forwarding addresses map and the original host