### PR TITLE
Bug fix: Install .ssl folder if doesn't exist

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -12,6 +12,10 @@ if [ ! -d "$SNAP_DATA/userdata/etc" ]; then
     mkdir -p $SNAP_DATA/userdata/etc
 fi
 
+if [ ! -d "$SNAP_DATA/userdata/edge_gw_identity/.ssl" ]; then
+    mkdir -p $SNAP_DATA/userdata/edge_gw_identity/.ssl
+fi
+
 if [ ! -d "$SNAP_DATA/localdata" ]; then
     mkdir -p $SNAP_DATA/localdata
 fi


### PR DESCRIPTION
Maestro needs a .ssl folder to exist before creating certificates

Non-existent certificates resulted in relayTerm not working