### PR TITLE
disable DEBUG for maestro dependencies

### DIFF
--- a/files/maestro/patches/0001-allow-DEBUG-build-flag-override-from-environment.patch
+++ b/files/maestro/patches/0001-allow-DEBUG-build-flag-override-from-environment.patch
@@ -1,0 +1,38 @@
+From cb805f6d0f838367714091e71f97b533baf1eb8e Mon Sep 17 00:00:00 2001
+From: Nic Costa <nic.costa@gmail.com>
+Date: Tue, 21 Apr 2020 09:54:21 -0500
+Subject: [PATCH] allow DEBUG build flag override from environment
+
+---
+ build-deps.sh                                                   | 2 +-
+ .../armPelionEdge/greasego/deps/src/greaseLib/logger.h          | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/build-deps.sh b/build-deps.sh
+index a1af33d..5b2cdd5 100755
+--- a/build-deps.sh
++++ b/build-deps.sh
+@@ -46,7 +46,7 @@ cd "${THIS_DIR}/vendor/github.com/armPelionEdge/greasego"
+ cd "${THIS_DIR}/vendor/github.com/armPelionEdge/greasego"
+ 
+ # build greasego
+-DEBUG=1 ./build.sh
++./build.sh
+ 
+ popd
+ 
+diff --git a/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/logger.h b/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/logger.h
+index a40b9ae..f91e5bb 100644
+--- a/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/logger.h
++++ b/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/logger.h
+@@ -224,7 +224,6 @@ struct uint64_t_eqstrP {
+ 
+ //#define LOGGER_HEAVY_DEBUG 1
+ #define MAX_IDENTICAL_FILTERS 16
+-#define LOGGER_HEAVY_DEBUG
+ #ifdef LOGGER_HEAVY_DEBUG
+ #pragma message "Build is Debug Heavy!!"
+ // confused? here: https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html
+-- 
+2.17.1
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -297,15 +297,16 @@ parts:
         cd maestro
         git checkout d6ab0da4238bb4d8b767db3f70af71db909fae1c
         git am patches/0001-PATCH-Fake-devicedb-running-on-local-machine.patch
+        git am ${SNAPCRAFT_PROJECT_DIR}/files/maestro/patches/0001-allow-DEBUG-build-flag-override-from-environment.patch
       override-build: |
         export GOPATH=${SNAPCRAFT_PART_BUILD}/go
         # Specify GOBIN so that maestro/build.sh doesn't do unexpected things
         export GOBIN=${GOPATH}/bin
         cd ${GOPATH}/src/github.com/armPelionEdge/maestro/
         # Build maestro dependencies
-        ./build-deps.sh
+        DEBUG= ./build-deps.sh
         # Build maestro
-        DEBUG=0 DEBUG2=0 ./build.sh
+        DEBUG= DEBUG2= ./build.sh
         # Install maestro into GOPATH/bin
         go install github.com/armPelionEdge/maestro
 


### PR DESCRIPTION
Confirmed that:
`journalctl -u snap.pelion-edge.maestro`
does not output debug messages