### PR TITLE
Remove relayterm credentials on factory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -3,11 +3,10 @@
 # This is present on some, but not all gateways, and is where logs are persisted.
 rm -f /var/log/syslog*
 
-rm -f ${SNAP_DATA}/userdata/edge_gw_identity/identity.json
+rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
 snap stop pelion-edge.kubelet || true
 
 # Stop and remove all existing docker containers and images
 docker stop $(docker ps -a -q) || true
 docker system prune --volumes -a -f || true
 
-rm -rf ${SNAP_DATA}/userdata/edge_gw_identity/.ssl


### PR DESCRIPTION
Remove stale credentials so they may be generated by the next restart.