### PR TITLE
edge-k8s.mbedcloud.com doesn't resolve

### DIFF
--- a/docs/kaas.md
+++ b/docs/kaas.md
@@ -38,7 +38,7 @@ Prerequisites:
    apiVersion: v1
    clusters:
    - cluster:
-       server: https://edge-k8s.mbedcloud.com
+       server: https://edge-k8s.us-east-1.mbedcloud.com
      name: edge-k8s
    contexts:
    - context:


### PR DESCRIPTION
edge-k8s.mbedcloud.com isn't a valid domain name and probably never will be.  According to @jrife, the correct DNS name is edge-k8s.us-east-1.mbedcloud.com