### PR TITLE
add nmcli package dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,6 +140,7 @@ parts:
       stage-packages:
         - network-manager
         - libslang2
+        - libatm1
       organize:
         usr/bin/nmcli: bin/nmcli
     mmcli:


### PR DESCRIPTION
This fixes the following build warning:

The 'nmcli' part is missing libraries that are not included in the snap
or base. They can be satisfied by adding the following entries to the
existing stage-packages for this part:
- libatm1