### PR TITLE
edge-core: don't preserve owner on fota tar extract

### DIFF
--- a/files/edge-core/scripts/edge-core-bootloader.sh
+++ b/files/edge-core/scripts/edge-core-bootloader.sh
@@ -20,7 +20,7 @@ function try_upgrade()
 	echo "Checking for ${UPGRADE_TGZ}"
 	if [ -e "${UPGRADE_TGZ}" ]; then
 		mkdir -p "${UPGRADE_WORKDIR}"
-		tar -xzf "${UPGRADE_TGZ}" -C "${UPGRADE_WORKDIR}"
+		tar --no-same-owner -xzf "${UPGRADE_TGZ}" -C "${UPGRADE_WORKDIR}"
 		# remove the upgrade tgz file so that we don't fall into an upgrade loop
 		rm "${UPGRADE_TGZ}"
 		pushd "${UPGRADE_WORKDIR}"


### PR DESCRIPTION
extract the fota tar archive as self rather than as the original
tar owner in order to prevent permission denied errors about
changing file ownership.