### PR TITLE
Updated edge-utils SHA to use the new CoAP addresses

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -251,7 +251,7 @@ parts:
         - python
         - build-essential
       source: https://github.com/armPelionEdge/edge-utils.git
-      source-commit: e7767290fb8613babe1ca04008bd1c7099756503
+      source-commit: 3342c0834042addb2716e48931d0f2118dca6356
       override-pull: |
         snapcraftctl pull
         cp ${SNAPCRAFT_PROJECT_DIR}/files/wwrelay-utils/package.json .


### PR DESCRIPTION
This PR fixes - https://jira.arm.com/browse/PELEDGE19-2944