### PR TITLE
Docker Power Failure fix

### DIFF
--- a/files/docker/bin/dockerd-wrapper
+++ b/files/docker/bin/dockerd-wrapper
@@ -47,6 +47,8 @@ trap - EXIT
 # use SNAP_DATA for most "data" bits
 mkdir -p \
 	"$SNAP_DATA/run" \
+	"/var/run/pelion-edge" \
+	"/var/run/pelion-edge/docker" \
 	"$SNAP_DATA/run/docker" \
 	"$SNAP_COMMON/var-lib-docker"
 
@@ -56,8 +58,8 @@ workaround_apparmor_profile_reload
 
 exec dockerd \
 	-G $default_socket_group \
-	--exec-root="$SNAP_DATA/run/docker" \
+	--exec-root="/var/run/pelion-edge/docker" \
 	--data-root="$SNAP_COMMON/var-lib-docker" \
-	--pidfile="$SNAP_DATA/run/docker.pid" \
+	--pidfile="/var/run/pelion-edge/docker.pid" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
 	"$@"


### PR DESCRIPTION
Root directory for execution state files and directory for pidfile needs to be present in tempfs. Keeping them in a non-tempfs directory may lead to corruption of files if there is an unexpected power failure. This might lead to dockerd failing to start again after reboot. Keeping these files in tempfs ensures that these files are wiped out on reboot. exec-root and pidfile options in dockerd command are /var/run/docker and /var/run/docker.pid respectively by default. (https://docs.docker.com/engine/reference/commandline/dockerd/)