### PR TITLE
Upgraded edge-core version to 0.13.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -192,7 +192,7 @@ parts:
     edge-core:
       plugin: cmake
       source: https://github.com/ARMmbed/mbed-edge.git
-      source-tag: 0.12.0
+      source-tag: 0.13.0
       build-packages:
         - build-essential
         - cmake


### PR DESCRIPTION
Release notes of edge-core - https://github.com/ARMmbed/mbed-edge/blob/master/CHANGELOG.md#release-0130-2020-29-04