### PR TITLE
Temporarily disable strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This repository contains snapcraft packaging for Pelion Edge. This lets you run 
 1. Use the `snap` utility to install the snap package:
 
    ```bash
-   sudo snap install pelion-edge_<version>_<arch>.snap
+   sudo snap install --devmode pelion-edge_<version>_<arch>.snap
    ```
 
    If you see the following message:
@@ -139,39 +139,16 @@ This repository contains snapcraft packaging for Pelion Edge. This lets you run 
     error: cannot find signatures with metadata for snap
     ```
 
-   add the `--dangerous` option
+   add the `--devmode` option
 
    ```bash
-    sudo snap install --dangerous pelion-edge_<version>_<arch>.snap
+    sudo snap install --devmode pelion-edge_<version>_<arch>.snap
     ```
 
-1. Hookup the following connections
+1. Hookup the snapd-control daemon
 
     ```bash
     sudo snap connect pelion-edge:snapd-control :snapd-control
-    sudo snap connect pelion-edge:modem-manager modem-manager:service
-    sudo snap connect pelion-edge:network-manager network-manager:service
-    sudo snap connect pelion-edge:network-control :network-control
-    sudo snap connect pelion-edge:privileged :docker-support
-    sudo snap connect pelion-edge:support :docker-support
-    sudo snap connect pelion-edge:firewall-control :firewall-control
-    sudo snap connect pelion-edge:docker-cli pelion-edge:docker-daemon
-    sudo snap connect pelion-edge:log-observe :log-observe
-    sudo snap connect pelion-edge:system-files :system-files
-    sudo snap connect pelion-edge:kernel-module-observe :kernel-module-observe
-    sudo snap connect pelion-edge:system-trace :system-trace
-    sudo snap connect pelion-edge:system-observe :system-observe
-    sudo snap connect pelion-edge:account-control :account-control
-    sudo snap connect pelion-edge:block-devices :block-devices
-    sudo snap connect pelion-edge:bluetooth-control :bluetooth-control
-    sudo snap connect pelion-edge:hardware-observe :hardware-observe
-    sudo snap connect pelion-edge:kubernetes-support :kubernetes-support
-    sudo snap connect pelion-edge:mount-observe :mount-observe
-    sudo snap connect pelion-edge:netlink-audit :netlink-audit
-    sudo snap connect pelion-edge:netlink-connector :netlink-connector
-    sudo snap connect pelion-edge:network-observe :network-observe
-    sudo snap connect pelion-edge:process-control :process-control
-    sudo snap connect pelion-edge:shutdown :shutdown
     ```
 ## Run Pelion Edge
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ base: core
 version: "1.13.1"
 summary: Pelion Edge
 description: Pelion Edge
-confinement: strict
+confinement: devmode
 grade: devel
 architectures:
   - amd64


### PR DESCRIPTION
Temporarily revert to devmode confinement until bugs in strict mode can
be resolved.  Plugs needed for strict mode are left intact since the do
not affect functionality in devmode.

Signed-off-by: Kyle Stein <kyle.stein@arm.com>