### PR TITLE
send all fp-edge log output to /dev/null by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,24 @@ Log files are captured by snap and are available with the following commands:
    journalctl -u snap.pelion-edge.edge-core -f
    ```
 
+## Runtime Configuration
+
+1. The maestro service may be configured with [maestro-shell](https://github.com/armpelionedge/maestro-shell) and with [devicedb](https://github.com/armpelionedge/devicedb).  See the README of each project for more information.
+1. The fp-edge service exposes a debug flag using snap configuration that can be viewed with `snap get` and configured with `snap set`.  The key is named `fp-edge.debug` and can be set to `true` or `false` (the default).  Setting the flag to true will cause fp-edge log output to be sent to the systemd journal and setting it to false will cause fp-edge log output to be redirected to /dev/null.
+```
+admin@localhost:~$ snap get pelion-edge
+Key      Value
+fp-edge  {...}
+admin@localhost:~$ snap get pelion-edge fp-edge
+Key            Value
+fp-edge.debug  false
+admin@localhost:~$ snap set pelion-edge fp-edge.debug=true
+admin@localhost:~$ snap get pelion-edge fp-edge
+Key            Value
+fp-edge.debug  true
+admin@localhost:~$
+```
+
 ## Known issues and troubleshooting
 
 ### Edge service errors

--- a/files/fog-proxy/scripts/launch-fp-edge.sh
+++ b/files/fog-proxy/scripts/launch-fp-edge.sh
@@ -5,6 +5,13 @@ EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts
 fi
+
+if [[ $(snapctl get fp-edge.debug) = "false" ]]; then
+    # this is known as bash exec redirection.
+    # see https://www.tldp.org/LDP/abs/html/x17974.html
+    exec >/dev/null 2>&1
+fi
+
 exec ${SNAP}/wigwag/system/bin/fp-edge \
     -proxy-uri=${EDGE_K8S_ADDRESS} \
     -tunnel-uri=ws://gateways.local$EDGE_PROXY_URI_RELATIVE_PATH \
@@ -14,4 +21,3 @@ exec ${SNAP}/wigwag/system/bin/fp-edge \
     -cert-strategy-options=device-cert-name=mbed.LwM2MDeviceCert \
     -cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey \
     -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}
-ls

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# check if we need to set a default value
+if [[ -z $(snapctl get fp-edge.debug) ]]; then
+    snapctl set fp-edge.debug=false
+fi


### PR DESCRIPTION
In an effort to reduce the amount of log data stored on disk
and sent over the network, all fp-edge log output is dropped
by default.

To enable logging at runtime, set the following snap configuration
and restart fp-edge:

    snap set pelion-edge fp-edge.debug=true

Setting this flag to true will cause fp-edge log output to be
sent to systemd journal.