### PR TITLE
fp-edge: add helpful log message if debug logs are disabled

### DIFF
--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -25,6 +25,7 @@ if ! grep -q "gateways.local" /etc/hosts; then
 fi
 
 if [[ $(snapctl get edge-proxy.debug) = "false" ]]; then
+    echo "edge-proxy logging is disabled.  To see logs, run \"snap set pelion-edge edge-proxy.debug=true\" and restart edge-proxy"
     # this is known as bash exec redirection.
     # see https://www.tldp.org/LDP/abs/html/x17974.html
     exec >/dev/null 2>&1


### PR DESCRIPTION
tell the user how to turn on fp-edge logs if logs are disabled