### PR TITLE
Specify localhost ip for kubelet

### DIFF
--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -21,4 +21,5 @@ exec ${SNAP}/wigwag/system/bin/kubelet \
     --cni-bin-dir=${SNAP}/wigwag/system/opt/cni/bin \
     --cni-conf-dir=${SNAP}/wigwag/system/etc/cni/net.d \
     --network-plugin=cni \
+    --node-ip=127.0.0.1 \
     --register-node=true


### PR DESCRIPTION
If no node ip is given kubelet, kubelet will assume that the node
name is a hostname and attempt to discover its ip address.  Since the
node name is set to the pelion cloud endpoint id (which is not a
hostname) this results in spurious DNS requests.  Note that the node ip
is not actually used for any function in this use case, so detting it to
localhost is sufficient.

Signed-off-by: Kyle Stein <kyle.stein@arm.com>