### PR TITLE
Update snap connect instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This repository contains snapcraft packaging for Pelion Edge. This lets you run 
     sudo snap connect pelion-edge:shutdown :shutdown
     ```
 
-1. Restart pelion-edge
+1. Restart pelion-edge or reboot the device so these connections take effect.
 
    ```bash
    sudo snap restart pelion-edge


### PR DESCRIPTION
Update README.md to instruct the user to restart pelion-edge after snap
connecting interfaces.  This fixes some issues that were caused by first
starting pelion-edge without the interfaces intact, such as docker
CLI access.