### PR TITLE
Set Node IP address in Kubelet

### DIFF
--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -15,7 +15,7 @@ fi
 IP_ADDR=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')
 
 if [ -n $IP_ADDR ]; then
-    NODE_IP_OPTION="--node-ip=$(IP_ADDR)"
+    NODE_IP_OPTION="--node-ip=$IP_ADDR"
 else
     NODE_IP_OPTION=""
 fi


### PR DESCRIPTION
Set the --node-ip option in Kubelet to the interface that has Internet access.

We make this change in order to stop Kubelet from making lots of DNS queries against the node name.  See here for the related logic: https://github.com/armPelionEdge/argus/blob/master/pkg/kubelet/nodestatus/setters.go#L153

One caveat of this change is that we're removing Kubelet's ability to adapt to IP address changes at run time.  It will require a restart of Kubelet when the host IP address changes.