### PR TITLE
Truncate logs during factory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -20,6 +20,7 @@
 # This is present on some, but not all gateways, and is where logs are persisted.
 rm -f /var/log/syslog*
 journalctl --vacuum-time=1s
+find /var/log -type f -print0 | xargs -0 truncate --size=0
 
 rm -rf ${SNAP_DATA}/userdata/edge_gw_identity
 snap stop pelion-edge.kubelet || true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,8 +9,8 @@ architectures:
   - amd64
 plugs:
     system-files:
-        read: [/proc, /etc, /run, /sys, /var/lib]
-        write: [/proc, /etc, /run, /var/lib]
+        read: [/proc, /etc, /run, /sys, /var/lib, /var/log]
+        write: [/proc, /etc, /run, /var/lib, /var/log]
     home:
         read: all
     support:
@@ -60,7 +60,7 @@ apps:
       restart-condition: always
       command: launch-edge-core.sh
       daemon: simple
-      plugs: [shutdown, hardware-observe, network-bind, network-control, network-observe, system-files, snapd-control]
+      plugs: [shutdown, hardware-observe, network-bind, network-control, network-observe, system-files, snapd-control, log-observe]
     edge-core-reset-storage:
       command: launch-edge-core.sh --reset-storage
       plugs: [hardware-observe, network-bind, network-control, network-observe, system-files]


### PR DESCRIPTION
Our snap can't successfully rm log files.  Instead, we truncate the logs
to 0 size so that customer data is removed during factory reset.