### PR TITLE
Remove apparmor ptrace restrictions for kubelet

### DIFF
--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -20,6 +20,11 @@ else
     NODE_IP_OPTION=""
 fi
 
+# Fix readlink permission denied in Ubuntu Core <20 for /proc/1/ns/*
+APPARMOR_PROFILE=/var/lib/snapd/apparmor/profiles/snap.${SNAP_INSTANCE_NAME}.kubelet
+sed -i 's/^\(deny ptrace\)/#\1/' $APPARMOR_PROFILE
+/sbin/apparmor_parser -r $APPARMOR_PROFILE
+
 exec ${SNAP}/wigwag/system/bin/kubelet \
     --root-dir=${SNAP_COMMON}/var/lib/kubelet \
     --offline-cache-path=${SNAP_COMMON}/var/lib/kubelet/store \


### PR DESCRIPTION
On Ubuntu versions older than 20, readlink requests read/write
permisssions instead of read-only, which inadvertently results in
permission denied when trying to access /proc/1/ns/*

This will fix the problem by removing write access (ptrace)
restrictions from the kubelet apparmor profile.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>