### PR TITLE
Added device ID to /etc/hosts for devicedb

### DIFF
--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -19,11 +19,14 @@
 
 EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
+DEVICE_ID=$(jq -r .deviceID ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/edge-proxy.conf.json)
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts
 fi
-
+if ! grep -q "$DEVICE_ID" /etc/hosts; then
+    echo "127.0.0.1 $DEVICE_ID" >> /etc/hosts
+fi
 if [[ $(snapctl get edge-proxy.debug) = "false" ]]; then
     echo "edge-proxy logging is disabled.  To see logs, run \"snap set pelion-edge edge-proxy.debug=true\" and restart edge-proxy"
     # this is known as bash exec redirection.


### PR DESCRIPTION
DeviceDB runs on localhost
Maestro wants devicedb to run on http://$DEVICE_ID:9000

Make sure /etc/hosts redirects http://$DEVICE_ID:9000 to localhost