### PR TITLE
Dockerfile: fix version locking of Go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,12 @@ RUN apt-get update && apt-get install -y \
 	curl jq squashfs-tools openssh-client git gosu
 
 # Install Go
-# Grab the go snap from the stable channel, unpack it in the proper place,
+# Download the go binary package, unpack it in the proper place,
 # and link the go binaries to make them available to snapcraft
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/go?version=1.13.5' | jq '.download_url' -r) --output go.snap && \
-	mkdir -p /snap/go && \
-	unsquashfs -d /snap/go/current go.snap && \
-	ln -sf /snap/go/current/bin/go /snap/bin/go && \
-	ln -sf /snap/go/current/bin/gofmt /snap/bin/gofmt
+RUN curl -L https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz | tar -xz && \
+    mv go /usr/local && \
+    ln -sf /usr/local/go/bin/go /usr/local/bin/go && \
+    ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # Install the script that sets up the user environment
 # and runs CMD as the current user instead of as root


### PR DESCRIPTION
The mechanism used to lock down the version of Go to 1.13.5 did
not work as intended and would instead always download the latest
version of Go from the stable channel, which at the time of this
commit is version 1.14.4.

This commit fixes the lockdown, and locks Go to version 1.14.4
since that's what we've been unknowingly running anyway.