### PR TITLE
Stop syslog deamon on fractory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -20,6 +20,9 @@
 # This is present on some, but not all gateways, and is where logs are persisted.
 rm -f /var/log/syslog*
 journalctl --vacuum-time=1s
+
+# Stop logging until next reboot and remove previous logs
+systemctl stop syslog.socket rsyslog.service
 find /var/log -type f -print0 | xargs -0 truncate --size=0
 
 rm -rf ${SNAP_DATA}/userdata/edge_gw_identity


### PR DESCRIPTION
In addition to removing old logs during a factory reset, the syslog
daemon will be stopped in order to prevent persistence of log messages
which occur after the factory reset but before reboot.

Signed-off-by: Kyle Stein <kyle.stein@arm.com>