### PR TITLE
Re-enable maestro DHCP control for networking

### DIFF
--- a/files/maestro/config/maestro-config-dell5000.yaml
+++ b/files/maestro/config/maestro-config-dell5000.yaml
@@ -7,7 +7,10 @@ imagePath: /tmp/maestro/images
 scratchPath: /tmp/maestro/scratch
 clientId: "{{ARCH_SERIAL_NUMBER}}"
 network:
-    disable: true
+  interfaces:
+    - if_name: eth0
+      dhcpv4: true
+      hw_addr: "{{ARCH_ETHERNET_MAC}}"
 platform_readers:
   - platform: "fsonly"
     params:


### PR DESCRIPTION
Now that maestro.config lives within snap-pelion-edge, port wwrelay-utils/edge-utils PRs into the snap repo

