### PR TITLE
Modify edge-core patch to include human readable platform version LWM2M

### DIFF
--- a/files/edge-core/patches/0001-Read-platform-version-files-into-LWM2M-resources.patch
+++ b/files/edge-core/patches/0001-Read-platform-version-files-into-LWM2M-resources.patch
@@ -1,12 +1,20 @@
-From 2239106554f652ff302685f5388383dc3e77d7dd Mon Sep 17 00:00:00 2001
+From d39060df57051d4d5814432b60a1968370ebf8ad Mon Sep 17 00:00:00 2001
 From: Michael Ray <mjray@umich.edu>
 Date: Wed, 25 Mar 2020 14:20:17 -0500
-Subject: [PATCH] Read platform version file into LWM2M resource /10252/0/10
+Subject: [PATCH 1/1] Read platform version files into LWM2M resources
 
-Check for a file specified in macro PLATFORM_VERSION_FILE
-If macro PLATFORM_VERSION_FILE is not found, use /etc/platform_version file
+Platform Version readable: /10252/0/10
+Platform Version MD5 hash: /10252/0/11
 
-If the file does not exist at all, version becomes -1 which was default
+Check for files specified in macros:
+* PLATFORM_VERSION_FILE
+* PLATFORM_VERSION_HASH_FILE
+
+If either macro is not found, use:
+* /etc/readable_version
+* /etc/platform_version
+
+If the files do not exist at all, version becomes -1 which was default
 before this change
 
 Note: /10252/0/6 is the package version, which is required to be  set
@@ -16,51 +24,52 @@ Originally, we wanted to use this LWM2M resource to store the version,
 but a FOTA would not complete without setting it to the expected time
 (named hash in the resource name)
 ---
- .../source/FirmwareUpdateResource.cpp         | 28 ++++++++++++++++++-
- 1 file changed, 27 insertions(+), 1 deletion(-)
+ .../lwm2m-mbed/source/FirmwareUpdateResource.cpp   | 55 ++++++++++++++++++++++
+ 1 file changed, 55 insertions(+)
 
 diff --git a/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp b/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
-index 1f50abd..c7f3313 100644
+index 1f50abd..9ce6098 100644
 --- a/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
 +++ b/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
-@@ -49,6 +49,10 @@
+@@ -49,6 +49,14 @@
  #define RESOURCE_VALUE(arg) #arg
  #endif
  
 +#ifndef PLATFORM_VERSION_FILE
-+#define PLATFORM_VERSION_FILE "/etc/platform_version"
++#define PLATFORM_VERSION_FILE "/etc/readable_version"
++#endif
++
++#ifndef PLATFORM_VERSION_HASH_FILE
++#define PLATFORM_VERSION_HASH_FILE "/etc/platform_version"
 +#endif
 +
  namespace FirmwareUpdateResource {
  
  /* send delayed response */
-@@ -88,6 +92,7 @@ static M2MResource *resourceState = NULL;
+@@ -88,6 +96,8 @@ static M2MResource *resourceState = NULL;
  static M2MResource *resourceResult = NULL;
  static M2MResource *resourceName = NULL;
  static M2MResource *resourceVersion = NULL;
 +static M2MResource *resourcePlatVersion = NULL;
++static M2MResource *resourcePlatVersionHash = NULL;
  
  /* function pointers to callback functions */
  static void (*externalPackageCallback)(const uint8_t *buffer, uint16_t length) = NULL;
-@@ -209,12 +214,33 @@ void FirmwareUpdateResource::Initialize(void)
-                 resourceVersion = updateInstance->create_dynamic_resource(
-                                       RESOURCE_VALUE(6), "PkgVersion", M2MResourceInstance::STRING, true);
-                 if (resourceVersion) {
--                    resourceVersion->set_operation(M2MBase::GET_ALLOWED);
-                     resourceVersion->set_value(defaultVersion, sizeof(defaultVersion) - 1);
-+                    resourceVersion->set_operation(M2MBase::GET_ALLOWED);
-                     resourceVersion->publish_value_in_registration_msg(true);
+@@ -215,6 +225,51 @@ void FirmwareUpdateResource::Initialize(void)
                      resourceVersion->set_auto_observable(true);
                  }
  
++                char buffer[33];
++                FILE *fp = NULL;
++
 +                /* Create Platform Version resource /10252/0/10 */
 +                resourcePlatVersion = updateInstance->create_dynamic_resource(
 +                                      RESOURCE_VALUE(10), "PlatVersion", M2MResourceInstance::STRING, true);
 +                if (resourcePlatVersion) {
-+                    FILE *fp = fopen(PLATFORM_VERSION_FILE, "r");
++                    fp = fopen(PLATFORM_VERSION_FILE, "r");
 +                    if (fp) {
-+                        char buffer[33] = "0.0.0";
 +                        /* Strip out the newline if exists since we don't want it in the LWM2M object */
++                        memset(buffer, 0, sizeof(buffer));
 +                        if (fgets(buffer, sizeof(buffer), fp) && buffer[strlen(buffer) - 1] == '\n') {
 +                            buffer[strlen(buffer)-1] = 0;
 +                        }
@@ -74,9 +83,30 @@ index 1f50abd..c7f3313 100644
 +                    resourcePlatVersion->set_auto_observable(true);
 +                }
 +
++                /* Create Platform Version Hash resource /10252/0/11 */
++                resourcePlatVersionHash = updateInstance->create_dynamic_resource(
++                                          RESOURCE_VALUE(11), "PlatVersionHash", M2MResourceInstance::STRING, true);
++                if (resourcePlatVersionHash) {
++                    fp = fopen(PLATFORM_VERSION_HASH_FILE, "r");
++                    if (fp) {
++                        /* Strip out the newline if exists since we don't want it in the LWM2M object */
++                        memset(buffer, 0, sizeof(buffer));
++                        if (fgets(buffer, sizeof(buffer), fp) && buffer[strlen(buffer) - 1] == '\n') {
++                            buffer[strlen(buffer)-1] = 0;
++                        }
++                        resourcePlatVersionHash->set_value((uint8_t*)buffer, strlen(buffer));
++                        fclose(fp);
++                    } else {
++                        resourcePlatVersionHash->set_value(defaultVersion, sizeof(defaultVersion) - 1);
++                    }
++                    resourcePlatVersionHash->set_operation(M2MBase::GET_ALLOWED);
++                    resourcePlatVersionHash->publish_value_in_registration_msg(true);
++                    resourcePlatVersionHash->set_auto_observable(true);
++                }
++
  #if !defined(ARM_UC_PROFILE_MBED_CLIENT_LITE) || (ARM_UC_PROFILE_MBED_CLIENT_LITE == 0)
                  /* Create Update resource /10252/0/9 */
                  resourceUpdate = updateInstance->create_dynamic_resource(
 -- 
-2.21.0
+2.10.1.windows.1
 

--- a/files/edge-core/src/mbed_cloud_client_user_config.h
+++ b/files/edge-core/src/mbed_cloud_client_user_config.h
@@ -43,7 +43,8 @@
 
 #define EDGE_RUNNING_IN_SNAP 1
 
-#define PLATFORM_VERSION_FILE "/var/snap/" SNAPCRAFT_PROJECT_NAME "/current/etc/platform_version"
+#define PLATFORM_VERSION_HASH_FILE "/var/snap/" SNAPCRAFT_PROJECT_NAME "/current/etc/platform_version"
+#define PLATFORM_VERSION_FILE "/var/snap/" SNAPCRAFT_PROJECT_NAME "/current/etc/readable_version"
 
 #endif /* MBED_CLIENT_USER_CONFIG_H */
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -262,7 +262,7 @@ parts:
         cp ${SNAPCRAFT_PART_SRC}/cmake/toolchains/mcc-linux-x86.cmake config/toolchain.cmake
         sed -i 's!/dev/random!/dev/urandom!' lib/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/Board_Specific/TARGET_x86_x64/pal_plat_x86_x64.c
         sed -i 's!\(MAX_RECONNECT_TIMEOUT\).*!\1 60!' lib/mbed-cloud-client/mbed-client/mbed-client/m2mconstants.h
-        git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-Read-platform-version-file-into-LWM2M-resource-10252.patch
+        git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-Read-platform-version-files-into-LWM2M-resources.patch
         git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-PELEDGE19-1193-Call-a-script-on-factory-reset.patch
         git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-use-customized-edge-core-update-scripts.patch
         git am ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-fix-calculation-of-remaining-buffer-size-when-callin.patch


### PR DESCRIPTION
Read file /etc/readable_version into a LWM2M object /10252/0/11

Keep the original functionality of reading /etc/platform_version
into LWM2M object /10252/0/10