### PR TITLE
make sure bootloader env vars are exported

### DIFF
--- a/files/edge-core/scripts/launch-edge-core.sh
+++ b/files/edge-core/scripts/launch-edge-core.sh
@@ -17,9 +17,9 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-PLATFORM_VERSION=${SNAP_DATA}/etc/platform_version
-READABLE_VERSION=${SNAP_DATA}/etc/readable_version
-VERSION_MAP=${SNAP_DATA}/etc/version_map.json
+export PLATFORM_VERSION=${SNAP_DATA}/etc/platform_version
+export READABLE_VERSION=${SNAP_DATA}/etc/readable_version
+export VERSION_MAP=${SNAP_DATA}/etc/version_map.json
 
 # make sure the PAL_FS_MOUNT_POINT_PRIMARY directory exists so it can be populated
 # with mcc_config


### PR DESCRIPTION
specifically, the VERSION_MAP wasn't available from within
the bootloader