### PR TITLE
Set node ip to fixed address

### DIFF
--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -41,17 +41,7 @@ function checkIp4()
 
 function getEdgeNetAddr()
 {
-   #EDGENET_SUBNET should be of the form 10.0.0.0/24
-   #we want to pul the highest available address for that subnet (10.255.255.254 in the example)
-   EDGENET_SUBNET=$(docker network inspect --format='{{range .IPAM.Config}}{{.Subnet}}{{end}}' edgenet)
-   net=$(echo $EDGENET_SUBNET | cut -d '/' -f 1)
-   hexnet=$(printf '%02x' ${net//./ })
-   masknum=$(echo $EDGENET_SUBNET | cut -d '/' -f 2)
-   mask=$((2**$masknum - 1))
-   hexmask=$(printf '%x' $mask)
-   hexip=$(printf '%08x' $((0x$hexnet | 0x$hexmask - 1)) )
-   dotip=$(printf '%d.%d.%d.%d' $(echo $hexip | sed 's/../0x& /g') )
-   echo $dotip
+    echo $(snapctl get kubelet.edgenet-gateway)
 }
 
 # Get the IP address of the interface with Internet access

--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -39,8 +39,23 @@ function checkIp4()
     return 0
 }
 
+function getEdgeNetAddr()
+{
+   #EDGENET_SUBNET should be of the form 10.0.0.0/24
+   #we want to pul the highest available address for that subnet (10.255.255.254 in the example)
+   EDGENET_SUBNET=$(docker network inspect --format='{{range .IPAM.Config}}{{.Subnet}}{{end}}' edgenet)
+   net=$(echo $EDGENET_SUBNET | cut -d '/' -f 1)
+   hexnet=$(printf '%02x' ${net//./ })
+   masknum=$(echo $EDGENET_SUBNET | cut -d '/' -f 2)
+   mask=$((2**$masknum - 1))
+   hexmask=$(printf '%x' $mask)
+   hexip=$(printf '%08x' $((0x$hexnet | 0x$hexmask - 1)) )
+   dotip=$(printf '%d.%d.%d.%d' $(echo $hexip | sed 's/../0x& /g') )
+   echo $dotip
+}
+
 # Get the IP address of the interface with Internet access
-IP_ADDR=$(ip route get 1.1.1.1 | grep -oP 'src \K\S+')
+IP_ADDR=$(getEdgeNetAddr)
 
 if checkIp4 $IP_ADDR;then
     NODE_IP_OPTION="--node-ip=$IP_ADDR"


### PR DESCRIPTION
The node-ip option for kublet will be set to the highest
non-broadcast address in the edgenet subnet.  Note that this
address will not necessarily have internet visibility.

Signed-off-by: Kyle Stein <kyle.stein@arm.com>