### PR TITLE
fix bug: failed to git clone docker-containerd

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -633,7 +633,7 @@ parts:
       plugin: make
       source: https://github.com/containerd/containerd.git
       # from : https://github.com/docker/docker-ce/blob/v18.06.1-ce/components/engine/hack/dockerfile/install/containerd.installer
-      source-commit: 468a545b9edcd5932818eb9de8e72413e616e86e
+      source-tag: v1.1.2
       override-build: |
         # setup the go build environment for containerd
         . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh


### PR DESCRIPTION
One of the repos cloned by the build process contains Windows
line endings and depending on the local user's git config may
cause further clone failures.  By forcing autocrlf to false,
we preserve the original files so that they show unmodified.

Edit: this comment is no longer completely accurate.  The cloned repo does contain Windows line endings, but adding a git autocrlf flag can't fix the issue because the cloned repo uses .gitattributes "eol" flag to enforce the line endings.