### PR TITLE
upgrade edge-proxy

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -302,7 +302,7 @@ parts:
     edge-proxy:
       plugin: go
       source: git@github.com:armPelionEdge/edge-proxy.git
-      source-commit: b0f66f21e84078ff52e11f59f1cc9890a0dfaa34
+      source-commit: 1e03559a81fe974e346598b5025862337c2c9081
       go-importpath: github.com/armPelionEdge/edge-proxy
       override-build: |
         snapcraftctl build


### PR DESCRIPTION
pull in a fix for websocket connections through an upstream HTTP
proxy.