### PR TITLE
don't immediately re-register after factory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -17,6 +17,12 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+# we write to a tmp file so that it is automatically deleted when
+# the device is rebooted, yet persists through a simple restart.  by
+# doing this, we prevent edge-core from immediately re-registering
+# after the factory reset is completed.
+touch /tmp/factory-reset-in-progress
+
 # Stop and remove all existing docker containers and images
 snapctl stop ${SNAP_INSTANCE_NAME}.kubelet || true
 docker stop $(docker ps -a -q) || true

--- a/files/edge-core/scripts/launch-edge-core.sh
+++ b/files/edge-core/scripts/launch-edge-core.sh
@@ -21,6 +21,11 @@ export PLATFORM_VERSION=${SNAP_DATA}/etc/platform_version
 export READABLE_VERSION=${SNAP_DATA}/etc/readable_version
 export VERSION_MAP=${SNAP_DATA}/etc/version_map.json
 
+if [ -e /tmp/factory-reset-in-progress ]; then
+    echo "edge-core refusing to start, factory reset in progress.  To complete the reset, reboot the device."
+    exit 0
+fi
+
 # make sure the PAL_FS_MOUNT_POINT_PRIMARY directory exists so it can be populated
 # with mcc_config
 if [ ! -d ${SNAP_DATA}/userdata/mbed ]; then


### PR DESCRIPTION
Fix an issue where edge-core immeditately re-registers to the
cloud after a factory reset.  We want a clean factory reset where
the device must reboot or poweroff before re-registration occurs.