### PR TITLE
rename snap-var edge-proxy.extern-http-proxy

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -55,7 +55,7 @@ find /var/log -type f -print0 | xargs -0 truncate --size=0
 
 # delete custom environment variables
 snapctl unset edge-proxy.debug
-snapctl unset edge-proxy.extern-http-proxy
+snapctl unset edge-proxy.extern-http-proxy-uri
 snapctl unset kubelet.edgenet-gateway
 snapctl unset kubelet.edgenet-subnet
 

--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -25,7 +25,7 @@ EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress ${SNAP_DATA}/userdata/edge_gw_i
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 DEVICE_ID=$(jq -r .deviceID ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/edge-proxy.conf.json)
-EXTERN_HTTP_PROXY=$(snapctl get edge-proxy.extern-http-proxy)
+EXTERN_HTTP_PROXY=$(snapctl get edge-proxy.extern-http-proxy-uri)
 
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -24,8 +24,8 @@ if [[ -z $(snapctl get edge-proxy.debug) ]]; then
     snapctl set edge-proxy.debug=false
 fi
 
-if [[ -z $(snapctl get edge-proxy.extern-http-proxy) ]]; then
-    snapctl set edge-proxy.extern-http-proxy=""
+if [[ -z $(snapctl get edge-proxy.extern-http-proxy-uri) ]]; then
+    snapctl set edge-proxy.extern-http-proxy-uri=""
 fi
 
 if [[ -z $(snapctl get kubelet.edgenet-subnet) ]]; then


### PR DESCRIPTION
rename the snap variable edge-proxy.extern-http-proxy to match
the name of the underlying option in edge-proxy, i.e.,
"extern-http-proxy-uri".