### PR TITLE
Add 'kubelet.offline-mode' configuration option

### DIFF
--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -59,9 +59,13 @@ APPARMOR_PROFILE=/var/lib/snapd/apparmor/profiles/snap.${SNAP_INSTANCE_NAME}.kub
 sed -i 's/^\(deny ptrace\)/#\1/' $APPARMOR_PROFILE
 /sbin/apparmor_parser -r $APPARMOR_PROFILE
 
+if [[ $(snapctl get kubelet.offline-mode) = "true" ]]; then
+    OFFLINE_CACHE_OPTION="--offline-cache-path=${SNAP_COMMON}/var/lib/kubelet/store"
+fi
+
 exec ${SNAP}/wigwag/system/bin/kubelet \
     --root-dir=${SNAP_COMMON}/var/lib/kubelet \
-    --offline-cache-path=${SNAP_COMMON}/var/lib/kubelet/store \
+    $OFFLINE_CACHE_OPTION \
     --fail-swap-on=false \
     --image-pull-progress-deadline=2m \
     --hostname-override=${DEVICE_ID} \

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -36,6 +36,10 @@ if [[ -z $(snapctl get kubelet.edgenet-gateway) ]]; then
     snapctl set kubelet.edgenet-gateway="10.0.0.1"
 fi
 
+if [[ -z $(snapctl get kubelet.offline-mode) ]]; then
+    snapctl set kubelet.offline-mode=true
+fi
+
 if [[ -z $(snapctl get edge-core.refresh-timeout) ]]; then
     snapctl set edge-core.refresh-timeout=300
 fi


### PR DESCRIPTION
Set snap set kubelet.offline-mode to false to disable offline mode.
Offline mode is on by default and will run pods even while disconnected
from the internet.