### PR TITLE
fix bug: kubectl fails to start after factory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -60,6 +60,10 @@ snapctl unset edge-proxy.debug
 snapctl unset edge-proxy.extern-http-proxy-uri
 snapctl unset kubelet.edgenet-gateway
 snapctl unset kubelet.edgenet-subnet
+# snapctl-unset doesn't call the configure hook, so we need to
+# call it manually so that default values are configured.
+# https://snapcraft.io/docs/using-snapctl
+${SNAP}/meta/hooks/configure
 
 # it's very important for this script to return success, otherwise
 # edge-core won't clean up mbed credentials


### PR DESCRIPTION
The absence of snap-vars causes bad behavior in our startup
scripts, but these snap-vars should always exist even if unset
because default values are supplied by the configure snap hook
script.  However, `snapctl` from within the snap environment
doesn't work the same way as `snap` from outside the snap
environment in that the configure hook isn't called, and
since all snap-vars are unset in the factory reset script, all
snap-vars are left undefined after factory reset.  We can fix the
situation by manually calling the configure hook to supply default
values.