### PR TITLE
fix permission denied when cleaning go modules

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -297,6 +297,8 @@ parts:
       source: https://github.com/PelionIoT/edge-proxy.git
       source-commit: 4fe1ccad2555062f7eef05f9bffebf650a1a4a06
       go-importpath: github.com/PelionIoT/edge-proxy
+      build-environment:
+        - GOFLAGS:  "$GOFLAGS -modcacherw"
       override-build: |
         snapcraftctl build
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
@@ -309,6 +311,8 @@ parts:
       source: https://github.com/PelionIoT/devicedb.git
       source-commit: a4ee46f3d9bc58b694e7563502142dfe265110cb
       go-importpath: github.com/armPelionEdge/devicedb
+      build-environment:
+        - GOFLAGS:  "$GOFLAGS -modcacherw"
       organize:
         'bin/*': wigwag/system/bin/
     edge-node-modules:
@@ -345,6 +349,8 @@ parts:
       plugin: go
       source: https://github.com/armPelionEdge/maestro-shell.git
       source-commit: aa2336b361555c471daab0d2dc21a7f750bdf813
+      build-environment:
+        - GOFLAGS:  "$GOFLAGS -modcacherw"
       override-pull: |
         # The go plugin also tries to run go get to fetch project dependencies. We just want to use the vendored dependencies.
         # Create the go workspace. This is normally done by the plugin
@@ -372,12 +378,16 @@ parts:
         install ${GOPATH}/bin/maestro-shell ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/maestro-shell
     yq:
       plugin: go
+      build-environment:
+        - GOFLAGS:  "$GOFLAGS -modcacherw"
       source: https://github.com/mikefarah/yq.git
       go-importpath: github.com/mikefarah/yq
     maestro:
       plugin: go
       source: https://github.com/armPelionEdge/maestro.git
       source-commit: a0adef8c579db2eaa15f08d1813eef417850f7d6
+      build-environment:
+        - GOFLAGS:  "$GOFLAGS -modcacherw"
       build-packages:
         - python
         - build-essential
@@ -459,7 +469,7 @@ parts:
         cd plugins
         git checkout ec8f6c99d030bd75337ae8bfc62fc02cdc462528
       override-build: |
-        export GOFLAGS="${GOFLAGS} -mod=vendor"
+        export GOFLAGS="${GOFLAGS} -mod=vendor -modcacherw"
         export GOPATH=${SNAPCRAFT_PART_SRC}/go
         export PROJECT_DIR=${GOPATH}/src/github.com/containernetworking/plugins
 
@@ -500,6 +510,8 @@ parts:
       source: https://github.com/PelionIoT/edge-kubelet.git
       source-commit: remove-offline-errors
       go-importpath: k8s.io/kubernetes
+      build-environment:
+        - GOFLAGS:  "$GOFLAGS -modcacherw"
       override-pull: |
         # The go plugin also tries to run go get to fetch project dependencies. We just want to use the vendored depdnencies.
         # Create the go workspace. This is normally done by the plugin


### PR DESCRIPTION
Fix the following issue when calling `snapcraft clean`
```
    Cleaning up parts directory
    Sorry, an error occurred in Snapcraft:
    [Errno 13] Permission denied: 'regenerate.bash'
    We would appreciate it if you anonymously reported this issue.
    No other data than the traceback and the version of snapcraft in use
    will be sent.
    Would you like to send this error data? (Yes/No/Always/View) [no]:
```

Calling snapcraft-clean after pulling and/or building Golang
projects that contain a go.mod file results in a permission
denied error because Go creates a read-only directory for
downloaded module dependencies, thereby requiring sudo to delete
the modules folder, or recursive permissions change prior to
clean.

A user can also call 'go clean -modcache' (no sudo required) to
delete downloded modules, but snapcraft doesn't offer a
override-clean step that we could use to provide a custom clean
script.

See here for more information: https://github.com/golang/go/issues/27455

To address the issue [1], Golang added a new flag in Go-1.14 [2]
that instructs the go command to leave the folder with default
permissions rather than forcing it read-only.

[1] https://github.com/golang/go/issues/31481
[2] https://golang.org/doc/go1.14