### PR TITLE
delete top-level snap vars on factory reset

### DIFF
--- a/files/edge-core/scripts/edge-core-factory-reset
+++ b/files/edge-core/scripts/edge-core-factory-reset
@@ -53,13 +53,11 @@ find /var/log -type f -print0 | xargs -0 truncate --size=0
 # delete unversioned r/w data
 [ -n "${SNAP_COMMON}" ] && rm -rf ${SNAP_COMMON}
 
-# delete custom environment variables
-snapctl unset edge-core.proxy
-snapctl unset edge-core.refresh-timeout
-snapctl unset edge-proxy.debug
-snapctl unset edge-proxy.extern-http-proxy-uri
-snapctl unset kubelet.edgenet-gateway
-snapctl unset kubelet.edgenet-subnet
+# delete custom environment variables.  we delete the whole
+# top-level key so that unknown keys are also cleaned up.
+snapctl unset edge-core
+snapctl unset edge-proxy
+snapctl unset kubelet
 # snapctl-unset doesn't call the configure hook, so we need to
 # call it manually so that default values are configured.
 # https://snapcraft.io/docs/using-snapctl


### PR DESCRIPTION
this fixes an issue where unknown keys are added by a user under
edge-core, edge-proxy, or kubelet, but these keys aren't being
cleaned up on factory reset.