### PR TITLE
Revert "Remove docker0 default bridge network"

### DIFF
--- a/files/docker/bin/dockerd-wrapper
+++ b/files/docker/bin/dockerd-wrapper
@@ -67,5 +67,4 @@ exec dockerd \
 	--pidfile="$SNAP_COMMON/var/run/docker.pid" \
 	--host="unix://$SNAP_COMMON/var/run/docker.sock" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
-	--bridge=none \
 	"$@"


### PR DESCRIPTION
This reverts commit 8c31311f4528be225d70d56e2e7f3b19371cdaf6.

This potentially breaks other dockerd's running on the host by removing
the docker0 interface.  Here's an example of the potential breakage: https://github.com/PelionIoT/pelion-dm-edge-docs/pull/124/files/05a82b95d5882639c1bf38eda8bb0aaaab6b8e18#r583052072