### PR TITLE
Updated pe-utils to 2.0.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -329,7 +329,7 @@ parts:
     pe-utils:
       plugin: nil
       source: https://github.com/armPelionEdge/pe-utils.git
-      source-commit: e18c85638f7fa555b586d60679beccc6cd4be821
+      source-commit: 810b73f3dcfd15a21b179bc58319d68f11aaa838
       override-build: |
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
         install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/version.json ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/


### PR DESCRIPTION
Features part of that release - https://github.com/PelionIoT/pe-utils/releases/tag/2.0.4
Majorly it removes the creation of self-signed certificates.