### PR TITLE
fota scripts: fix check for file existence

### DIFF
--- a/files/edge-core/scripts/arm_update_activate.sh
+++ b/files/edge-core/scripts/arm_update_activate.sh
@@ -28,9 +28,9 @@
 mkdir -p "$UPGRADE_DIR"
 
 # copy header to location to be applied by bootloader
-[ -n "$HEADER" ] && cp "$HEADER" "$UPGRADE_HDR"
+[ -f "$HEADER" ] && cp "$HEADER" "$UPGRADE_HDR"
 # copy firmware to location to be applied by bootloader
-[ -n "$FIRMWARE" ] && cp "$FIRMWARE" "$UPGRADE_TGZ"
+[ -f "$FIRMWARE" ] && cp "$FIRMWARE" "$UPGRADE_TGZ"
 # create fake installer.bin until we figure out if it's needed for anything
 # the size originates from struct _arm_uc_installer_details_t in arm_uc_types.h
 # see https://github.com/ARMmbed/mbed-edge/blob/master/lib/mbed-cloud-client/update-client-hub/modules/common/update-client-common/arm_uc_types.h#L74

--- a/files/edge-core/scripts/arm_update_active_details.sh
+++ b/files/edge-core/scripts/arm_update_active_details.sh
@@ -26,4 +26,6 @@
 . $(dirname "$0")/arm_update_cmdline.sh
 
 # copy header if present
-[ -n "$ACTIVE_HDR" ] && cp "$ACTIVE_HDR" "$HEADER"
+[ -f "$ACTIVE_HDR" ] && cp "$ACTIVE_HDR" "$HEADER"
+
+exit 0

--- a/files/edge-core/scripts/arm_update_installer.sh
+++ b/files/edge-core/scripts/arm_update_installer.sh
@@ -28,6 +28,6 @@
 
 . $(dirname "$0")/arm_update_cmdline.sh
 
-[ -e "${UPGRADE_INS}" ] && cp "${UPGRADE_INS}" "${ACTIVE_INS}"
+[ -f "${UPGRADE_INS}" ] && cp "${UPGRADE_INS}" "${ACTIVE_INS}"
 
 exit 0


### PR DESCRIPTION
it doesn't make sense to check a bash variable for empty string
if the variable is going to be used to copy a file.  the correct
test is to check whether the file exists first before copying.