### PR TITLE
Add Edge-Proxy HTTP(S) tunnel snap vars

### DIFF
--- a/connect.sh
+++ b/connect.sh
@@ -43,3 +43,4 @@ sudo snap connect ${SNAP_NAME}:network-observe     :network-observe
 sudo snap connect ${SNAP_NAME}:process-control     :process-control
 sudo snap connect ${SNAP_NAME}:shutdown            :shutdown
 sudo snap connect ${SNAP_NAME}:dbus-wpa            wpa-supplicant:service
+sudo snap connect ${SNAP_NAME}:home                :home

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -28,6 +28,30 @@ if [[ -z $(snapctl get edge-proxy.extern-http-proxy-uri) ]]; then
     snapctl set edge-proxy.extern-http-proxy-uri=""
 fi
 
+if [[ -z $(snapctl get edge-proxy.http-tunnel-listen) ]]; then
+    snapctl set edge-proxy.http-tunnel-listen=""
+fi
+
+if [[ -z $(snapctl get edge-proxy.https-tunnel-listen) ]]; then
+    snapctl set edge-proxy.https-tunnel-listen=""
+fi
+
+if [[ -z $(snapctl get edge-proxy.https-tunnel-tls-cert) ]]; then
+    snapctl set edge-proxy.https-tunnel-tls-cert=""
+fi
+
+if [[ -z $(snapctl get edge-proxy.https-tunnel-tls-key) ]]; then
+    snapctl set edge-proxy.https-tunnel-tls-key=""
+fi
+
+if [[ -z $(snapctl get edge-proxy.https-tunnel-username) ]]; then
+    snapctl set edge-proxy.https-tunnel-username=""
+fi
+
+if [[ -z $(snapctl get edge-proxy.https-tunnel-password) ]]; then
+    snapctl set edge-proxy.https-tunnel-password=""
+fi
+
 if [[ -z $(snapctl get kubelet.edgenet-subnet) ]]; then
     snapctl set kubelet.edgenet-subnet="10.0.0.0/24"
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,7 +115,7 @@ apps:
       restart-condition: always
       command: launch-edge-proxy.sh
       daemon: simple
-      plugs: [network-bind, network-control]
+      plugs: [network-bind, network-control, home]
     identity:
       command: launch-pelion-identity.sh $SNAP $SNAP_DATA
       daemon: simple


### PR DESCRIPTION
Add snap variables to edge-proxy config hook and startup script so that the user can pass HTTP(S) tunnel configuration to edge-proxy.