### PR TITLE
Add Edge-proxy external proxy cacert option

### DIFF
--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -41,6 +41,13 @@ else
     EXTERN_ARG=-extern-http-proxy-uri=$EXTERN_HTTP_PROXY
 fi
 
+EXTERN_HTTP_PROXY_CACERT=$(snapctl get edge-proxy.extern-http-proxy-cacert)
+if [[ $EXTERN_HTTP_PROXY_CACERT = "" ]]; then
+    EXTERN_CACERT_ARG=
+else
+    EXTERN_CACERT_ARG=-extern-http-proxy-cacert=$EXTERN_HTTP_PROXY_CACERT
+fi
+
 HTTP_TUNNEL="$(snapctl get edge-proxy.http-tunnel-listen)"
 if [[ "${HTTP_TUNNEL}" = "" ]]; then
     HTTP_TUNNEL_ARGS=
@@ -91,6 +98,7 @@ exec ${SNAP}/wigwag/system/bin/edge-proxy \
     -cert-strategy-options=device-cert-name=mbed.LwM2MDeviceCert \
     -cert-strategy-options=private-key-name=mbed.LwM2MDevicePrivateKey \
     ${EXTERN_ARG} \
+    ${EXTERN_CACERT_ARG} \
     ${HTTP_TUNNEL_ARGS} \
     ${HTTPS_TUNNEL_ARGS} \
     -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -28,6 +28,10 @@ if [[ -z $(snapctl get edge-proxy.extern-http-proxy-uri) ]]; then
     snapctl set edge-proxy.extern-http-proxy-uri=""
 fi
 
+if [[ -z $(snapctl get edge-proxy.extern-http-proxy-cacert) ]]; then
+    snapctl set edge-proxy.extern-http-proxy-cacert=""
+fi
+
 if [[ -z $(snapctl get edge-proxy.http-tunnel-listen) ]]; then
     snapctl set edge-proxy.http-tunnel-listen=""
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -290,7 +290,7 @@ parts:
     edge-proxy:
       plugin: go
       source: https://github.com/PelionIoT/edge-proxy.git
-      source-commit: fb0810668fc2beca45a888d7a13860cfcca31bbf
+      source-commit: 595c110019cf4360e5fca981028c595e72abce12
       go-importpath: github.com/PelionIoT/edge-proxy
       build-environment:
         - GOFLAGS:  "$GOFLAGS -modcacherw"


### PR DESCRIPTION
Pass variables into edge-proxy to specify a CA cert for the external
proxy.  Update edge-proxy to a version that supports this option.