### PR TITLE
remove reset-storage from help.md

### DIFF
--- a/files/help/help.md
+++ b/files/help/help.md
@@ -11,9 +11,5 @@
 * view logs
     sudo snap logs pelion-edge
 
-* reset storage
-    sudo snap stop pelion-edge
-    sudo pelion-edge.edge-core-reset-storage
-
 * startup parameters
     Modify startup parameters by editing the file ${SNAP_DATA}/edge-core.conf, which is typically /var/snap/pelion-edge/current/edge-core.conf.


### PR DESCRIPTION
the reset-storage command was removed a long time ago but
wasn't removed from the help.md printed by pelion-edge.help.