### PR TITLE
Allow disabling of the default docker bridge(docker0)

### DIFF
--- a/docs/kaas.md
+++ b/docs/kaas.md
@@ -327,3 +327,16 @@ From the the gateway terminal, or relayterm, use the following commands:
 1. `snap restart pelion-edge`
 
 This should cause existing containers to change their addresses so they're in the 192.168.0.0/24 subnet.
+
+
+## Disabling Default Docker Bridge
+
+In many cases, the administrator will want to disable the default docker
+bridge(`docker0`).
+
+From the the gateway terminal, or relayterm, use the following command:
+
+1. `snap set pelion-edge docker.bridge=disable`
+1. `snap restart pelion-edge`
+
+This should cause the `docker0` network interface to disappear.

--- a/files/docker/bin/dockerd-wrapper
+++ b/files/docker/bin/dockerd-wrapper
@@ -72,6 +72,12 @@ workaround_apparmor_profile_reload
 
 workaround_missing_xdg_runtime_dir
 
+if [ $(snapctl get docker.bridge) = "disable" ]; then
+	BRIDGEOPTS="--bridge=none"
+else
+	BRIDGEOPTS=""
+fi
+
 exec dockerd \
 	-G $default_socket_group \
 	--exec-root="$SNAP_COMMON/var/run/docker" \
@@ -79,4 +85,5 @@ exec dockerd \
 	--pidfile="$SNAP_COMMON/var/run/docker.pid" \
 	--host="unix://$SNAP_COMMON/var/run/docker.sock" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
+	$BRIDGEOPTS \
 	"$@"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -68,6 +68,10 @@ if [[ -z $(snapctl get kubelet.offline-mode) ]]; then
     snapctl set kubelet.offline-mode=true
 fi
 
+if [[ -z $(snapctl get docker.bridge) ]]; then
+    snapctl set docker.bridge=enable
+fi
+
 if [[ -z $(snapctl get edge-core.refresh-timeout) ]]; then
     snapctl set edge-core.refresh-timeout=300
 fi


### PR DESCRIPTION
In many cases, the user will want to disable the default docker bridge
since it's not being used by edge.  This prevents potential IP subnet
conflicts with other networks.

We're leaving it enabled by default in the case that the user has
dockerd with the docker0 bridge running on the host or in another snap
since we don't want to accidentally disable `docker0` if it's being used.