### PR TITLE
Add local host and forward address for container domain

### DIFF
--- a/files/edge-proxy/scripts/launch-edge-proxy.sh
+++ b/files/edge-proxy/scripts/launch-edge-proxy.sh
@@ -23,11 +23,16 @@ fi
 
 EDGE_K8S_ADDRESS=$(jq -r .edgek8sServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
+CONTAINERS_ADDRESS=$(jq -r .containerServicesAddress ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 DEVICE_ID=$(jq -r .deviceID ${SNAP_DATA}/userdata/edge_gw_identity/identity.json)
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path ${SNAP_DATA}/edge-proxy.conf.json)
 
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts
+fi
+
+if ! grep -q "containers.local" /etc/hosts; then
+    echo "127.0.0.1 containers.local" >> /etc/hosts
 fi
 
 if ! grep -q "$DEVICE_ID" /etc/hosts; then
@@ -101,4 +106,4 @@ exec ${SNAP}/wigwag/system/bin/edge-proxy \
     ${EXTERN_CACERT_ARG} \
     ${HTTP_TUNNEL_ARGS} \
     ${HTTPS_TUNNEL_ARGS} \
-    -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}
+    -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"\,\"containers.local\":\"${CONTAINERS_ADDRESS#"https://"}\"}


### PR DESCRIPTION
1. Modify edge-proxy launch script to add new forwarding address for containers domain
2. Add `containers.local` to the list of known hosts