### PR TITLE
Upgrade pe-utils to 2.0.7

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -321,7 +321,7 @@ parts:
     pe-utils:
       plugin: nil
       source: https://github.com/PelionIoT/pe-utils.git
-      source-commit: 810b73f3dcfd15a21b179bc58319d68f11aaa838
+      source-tag: 2.0.7
       override-build: |
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
         install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/version.json ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/


### PR DESCRIPTION
This version of pe-utils mainly add a generic derivation in identity-tool to generate edge gw urls from all possible values of LwM2M service address. This should allow snap-pelion-edge gateways to connect with any Pelion cloud and on-prem instance.