### PR TITLE
Print versions

### DIFF
--- a/files/help/help.md
+++ b/files/help/help.md
@@ -1,4 +1,6 @@
 = Pelion Edge =
+* version
+    Prints the version of each pelion-edge component.
 
 == edge-core ==
 

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -20,7 +20,7 @@ echo -n "pe-utils: "; ${SNAP}/wigwag/pe-utils/identity-tools/developer_identity/
 echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
 echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
 echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
-echo -n "maestro-shell: "; ${SNAP}/wigwag/system/bin/maestro-shell -h | grep ver
+echo -n "maestro-shell: "; cat ${SNAP}/wigwag/etc/maestro-shell.VERSION
 echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
 echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version
 if [ "${SHOW_DOCKER}" = "true" ]; then

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -22,7 +22,7 @@ echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
 echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
 echo -n "maestro-shell: "; cat ${SNAP}/wigwag/etc/maestro-shell.VERSION
 echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
-echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version
+echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version | cut -d' ' -f2
 if [ "${SHOW_DOCKER}" = "true" ]; then
 	echo -n "docker: "; ${SNAP}/bin/docker --version
 	echo -n "docker-runc: "; ${SNAP}/bin/docker-runc --version

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -19,7 +19,7 @@ echo -n "relay-term: "; cat ${SNAP}/wigwag/etc/edge-node-modules.VERSION
 echo -n "pe-utils: "; ${SNAP}/wigwag/pe-utils/identity-tools/developer_identity/create-dev-identity.sh -V
 echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
 echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
-echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
+echo -n "maestro: "; cat ${SNAP}/wigwag/etc/maestro.VERSION
 echo -n "maestro-shell: "; cat ${SNAP}/wigwag/etc/maestro-shell.VERSION
 echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
 echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version | cut -d' ' -f2

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+THISFILE=$(basename $0)
+if [[ -e "${SNAP_DATA}/$THISFILE" ]] && [[ "$0" != "${SNAP_DATA}/$THISFILE" ]]; then
+    exec ${SNAP_DATA}/$THISFILE $@
+fi
+
+SHOW_DOCKER="false"
+
+while [ -n "$1" ]; do
+	case "$1" in
+	--all) SHOW_DOCKER="true";;
+	*) echo "$1 not supported";;
+	esac
+	shift
+done
+
+echo "relay-term: unsupported"
+echo -n "pe-utils: "; ${SNAP}/wigwag/pe-utils/identity-tools/developer_identity/create-dev-identity.sh -V
+echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
+echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
+echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
+echo -n "maestro-shell: "; ${SNAP}/wigwag/system/bin/maestro-shell -h | grep ver
+echo "edge-proxy: unsupported"
+echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version
+if [ "${SHOW_DOCKER}" = "true" ]; then
+	echo -n "docker: "; ${SNAP}/bin/docker --version
+	echo -n "docker-runc: "; ${SNAP}/bin/docker-runc --version
+	echo -n "docker-containerd: "; ${SNAP}/bin/docker-containerd --version
+	echo -n "docker-init: "; ${SNAP}/bin/docker-init --version
+fi

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -21,7 +21,7 @@ echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
 echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
 echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
 echo -n "maestro-shell: "; ${SNAP}/wigwag/system/bin/maestro-shell -h | grep ver
-echo "edge-proxy: unsupported"
+echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
 echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version
 if [ "${SHOW_DOCKER}" = "true" ]; then
 	echo -n "docker: "; ${SNAP}/bin/docker --version

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -15,7 +15,7 @@ while [ -n "$1" ]; do
 	shift
 done
 
-echo "relay-term: unsupported"
+echo -n "relay-term: "; cat ${SNAP}/wigwag/etc/edge-node-modules.VERSION
 echo -n "pe-utils: "; ${SNAP}/wigwag/pe-utils/identity-tools/developer_identity/create-dev-identity.sh -V
 echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
 echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-THISFILE=$(basename $0)
-if [[ -e "${SNAP_DATA}/$THISFILE" ]] && [[ "$0" != "${SNAP_DATA}/$THISFILE" ]]; then
-    exec ${SNAP_DATA}/$THISFILE $@
-fi
-
 SHOW_DOCKER="false"
 
 while [ -n "$1" ]; do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -399,6 +399,8 @@ parts:
         done
         # fixup the SNAP and SNAP_DATA variables in the config files based on the snap name
         sed -i "s!/snap/pelion-edge!/snap/${SNAPCRAFT_PROJECT_NAME}!" ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates/*.yaml
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/maestro.VERSION
     cni:
       plugin: go
       source: https://github.com/containernetworking/plugins.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -179,6 +179,8 @@ apps:
         - docker-daemon
     docker-help:
       command: bin/help
+    version:
+      command: bin/print-versions
 parts:
     help:
       plugin: dump
@@ -186,6 +188,14 @@ parts:
       override-build: |
         snapcraftctl build
         chmod a+x bin/print-help
+    version:
+      plugin: dump
+      source: files/version/
+      override-build: |
+        snapcraftctl build
+        chmod a+x print-versions.sh
+      organize:
+        print-versions.sh: bin/print-versions
     platform-version:
       plugin: dump
       source: files/platform-version/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -322,6 +322,10 @@ parts:
       source: https://github.com/PelionIoT/edge-node-modules.git
       source-commit: bcafcba2e6602ef486a8975c67a1df3872289499
       source-subdir: relay-term
+      override-build: |
+        snapcraftctl build
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/edge-node-modules.VERSION
       organize:
         'config': wigwag/wigwag-core-modules/relay-term/config
         'node_modules': wigwag/wigwag-core-modules/relay-term/node_modules

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -353,6 +353,8 @@ parts:
         ./build-deps.sh
         # Build maestro-shell
         snapcraftctl build
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/maestro-shell.VERSION
       organize:
         bin/maestro-shell: wigwag/system/bin/maestro-shell
     yq:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -322,7 +322,7 @@ parts:
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
         install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/version.json ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
-        cp -r . ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
+        cp -r identity-tools ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils/
         chmod -R 0755 ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
     maestro-shell:
       plugin: go

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -299,6 +299,8 @@ parts:
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
         install ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/config/edge-proxy.conf.json ${SNAPCRAFT_PART_INSTALL}/
         install ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/scripts/launch-edge-proxy.sh ${SNAPCRAFT_PART_INSTALL}/
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/edge-proxy.VERSION
       organize:
         bin/edge-proxy: wigwag/system/bin/edge-proxy
     devicedb:


### PR DESCRIPTION
Add a new snap command `pelion.edge.version` that prints the version of all the installed pelion-edge parts.