### PR TITLE
Fix factory reset failure to clear syslog files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -230,6 +230,7 @@ parts:
       source-tag: 0.16.1
       build-environment:
         - COAP_PORT_OVERRIDE_443: "false"
+      stage-packages: [coreutils]
       override-pull: |
         snapcraftctl pull
         # mbed_cloud_dev_credentials.c is required if DEVELOPER_MODE=ON


### PR DESCRIPTION
Fixes this error message during factory reset:

    = AppArmor =
    Time: Jul 09 13:54:54
    Log: apparmor="DENIED" operation="open"
    profile="snap.pelion-edge.edge-core" name="/usr/bin/truncate" pid=4950
    comm="bash" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
    File: /usr/bin/truncate (read)
    Suggestions:
    * adjust snap to ship 'truncate'
    * adjust program to use relative paths if the snap already ships
    * 'truncate'

The 'truncate' utility is included in the coreutils package.