### PR TITLE
Add pe-terminal package to enable go-based relay-term

### DIFF
--- a/files/pe-terminal/config/pe-terminal.conf.json
+++ b/files/pe-terminal/config/pe-terminal.conf.json
@@ -1,0 +1,5 @@
+{
+	"cloud": "ws://gateways.local:8080/relay-term",
+	"command": "/bin/bash",
+	"logLevel": "info"
+}

--- a/files/pe-terminal/launch-pe-terminal.sh
+++ b/files/pe-terminal/launch-pe-terminal.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ ! -f "$SNAP_DATA/pe-terminal.conf.json" ]; then
+    cp "$SNAP/pe-terminal.conf.json" "$SNAP_DATA/pe-terminal.conf.json"
+fi
+
+exec ${SNAP}/wigwag/system/bin/pe-terminal -config=$SNAP_DATA/pe-terminal.conf.json

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -20,3 +20,6 @@
 # disable auto-start on some services.
 # as of snapcraft v3.8, services can't be configured to be disabled by default
 # in snapcraft.yaml and must instead be disabled in the install hook.
+
+# disable relay-term in favour to use pe-terminal.
+snapctl stop --disable ${SNAP_INSTANCE_NAME}.relay-term

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -118,6 +118,15 @@ apps:
       command: launch-edge-proxy.sh
       daemon: simple
       plugs: [network-bind, network-control, home]
+    pe-terminal:
+      restart-delay: 5s
+      restart-condition: always
+      after: [edge-proxy]
+      command: launch-pe-terminal.sh
+      daemon: simple
+      environment:
+        TERM: xterm-256color
+      plugs: [network, ssh-keys, ssh-public-keys, network-bind, network-control, network-observe, snapd-control, shutdown, network-manager, modem-manager, log-observe]
     identity:
       command: launch-pelion-identity.sh $SNAP $SNAP_DATA
       daemon: simple
@@ -419,6 +428,20 @@ parts:
         git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/edge-proxy.VERSION
       organize:
         bin/edge-proxy: wigwag/system/bin/edge-proxy
+    pe-terminal:
+      plugin: go
+      source: https://github.com/PelionIoT/pe-terminal.git
+      source-tag: v1.0.0
+      go-importpath: github.com/PelionIoT/pe-terminal
+      build-environment:
+        - GOFLAGS:  "$GOFLAGS -modcacherw"
+      override-build: |
+        snapcraftctl build
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
+        install ${SNAPCRAFT_PROJECT_DIR}/files/pe-terminal/config/pe-terminal.conf.json ${SNAPCRAFT_PART_INSTALL}/
+        install ${SNAPCRAFT_PROJECT_DIR}/files/pe-terminal/launch-pe-terminal.sh ${SNAPCRAFT_PART_INSTALL}/
+      organize:
+        bin/pe-terminal: wigwag/system/bin/pe-terminal
     edge-node-modules:
       plugin: nodejs
       nodejs-version: 12.20.1


### PR DESCRIPTION
This PR adds go-based relay-term package called [pe-terminal](https://github.com/PelionIoT/pe-terminal) which will be enabled by default, disabling the old nodejs one instead of removing it, so that we can bring up the old one incase some issue is encountered with the new one.

<del>**Note**: CI builds might fail as the repo is currently private, we're working on making it public.