### PR TITLE
Add PR check to sure that base branch is dev

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -1,0 +1,22 @@
+name: Check PR Base
+on:
+  pull_request:
+    types: [opened, edited]
+jobs:
+  check-pr-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject PR due to incorrect base
+        if: ( !(github.base_ref == 'master' && github.head_ref == 'dev') && github.base_ref != 'dev') && (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.base.ref))
+        uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          event: REQUEST_CHANGES
+          body: 'Please change your PR base to dev branch.'
+      - name: Approve PR because it's based against dev branch
+        if: ((github.base_ref == 'master' && github.head_ref == 'dev') || github.base_ref == 'dev') && github.event.changes.base && github.event.changes.base.ref.from != 'dev'
+        uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          event: APPROVE
+          body: 'Your PR is based against the dev branch.  Looks good.'


### PR DESCRIPTION
We've had some issues accidentally merging PRs against master.  By
default all PRs should be against dev branch.  This github action should
ensure that.  There's one exception: PRs from dev to master are
allowed(for releases).