### PR TITLE
make snap refresh work better over cellular connection

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -76,6 +76,10 @@ if [[ -z $(snapctl get edge-core.refresh-timeout) ]]; then
     snapctl set edge-core.refresh-timeout=300
 fi
 
+if [[ -z $(snapctl get edge-core.network-wait-timeout) ]]; then
+    snapctl set edge-core.network-wait-timeout=1200
+fi
+
 if [[ -z $(snapctl get edge-core.proxy) ]]; then
     snapctl set edge-core.proxy=""
 fi


### PR DESCRIPTION
Enhance the snap-refresh functionality over a cellular connection.  Note
that the changes are based on tag v1.21.1

List of changes:

  *   Instead of 'snap refresh'; get the snap list & refresh one snap at a time
  *   Before refreshing each snap, wait for a configurable period (default 1200
seconds) if there is no  network connectivity. (There is no facility to make
snapd check for network connection before executing a command)

Cases that are handled by the changes:

  *   Updating kernel snap / gadget snap auto-reboots the device. During
powerup, the device takes  ~ 1  minute to establish connection over cellular in
best case.
  *   Updating modem-manager, network-manager may break & make the data
connection over cellular. Snap refresh operation should wait for connection to
be up before proceeding.