### PR TITLE
Add socket proxy to snap

### DIFF
--- a/files/bouncer/scripts/launch-bouncer.sh
+++ b/files/bouncer/scripts/launch-bouncer.sh
@@ -18,4 +18,4 @@
 # ----------------------------------------------------------------------------
 
 # add ${SNAP} to PATH edge-core can run the factory reset script: edge-core-factory-reset
-exec env PATH=${PATH}:${SNAP} ${SNAP}/bin/socket-proxy ${SNAP_COMMON}/var/run/docker-proxy.sock ${SNAP_COMMON}/var/run/docker.sock
+exec env PATH=${PATH}:${SNAP} ${SNAP}/bin/bouncer ${SNAP_COMMON}/var/run/docker-proxy.sock ${SNAP_COMMON}/var/run/docker.sock

--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -65,6 +65,12 @@ if [[ $(snapctl get kubelet.offline-mode) = "true" ]]; then
     OFFLINE_CACHE_OPTION="--offline-cache-path=${SNAP_COMMON}/var/lib/kubelet/store"
 fi
 
+if [[ $(snapctl get kubelet.container-signing) = "true" ]]; then
+    DOCKER_SOCK_PATH="/var/run/docker.sock"
+else
+    DOCKER_SOCK_PATH="/var/run/docker-proxy.sock"
+fi
+
 exec ${SNAP}/wigwag/system/bin/kubelet \
     --root-dir=${SNAP_COMMON}/var/lib/kubelet \
     $OFFLINE_CACHE_OPTION \

--- a/files/socket-proxy/scripts/launch-socket-proxy.sh
+++ b/files/socket-proxy/scripts/launch-socket-proxy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021, Arm Limited and affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+# add ${SNAP} to PATH edge-core can run the factory reset script: edge-core-factory-reset
+exec env PATH=${PATH}:${SNAP} ${SNAP}/bin/socket-proxy ${SNAP_COMMON}/var/run/docker-proxy.sock ${SNAP_COMMON}/var/run/docker.sock

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -18,6 +18,7 @@ echo -n "maestro: "; cat ${SNAP}/wigwag/etc/maestro.VERSION
 echo -n "maestro-shell: "; cat ${SNAP}/wigwag/etc/maestro-shell.VERSION
 echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
 echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version | cut -d' ' -f2
+echo -n "bouncer: "; cat ${SNAP}/wigwag/etc/bouncer.VERSION
 if [ "${SHOW_DOCKER}" = "true" ]; then
 	echo -n "docker: "; ${SNAP}/bin/docker --version
 	echo -n "docker-runc: "; ${SNAP}/bin/docker-runc --version

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -651,4 +651,4 @@ parts:
         snapcraftctl build
         install ${SNAPCRAFT_PROJECT_DIR}/files/bouncer/scripts/launch-bouncer.sh ${SNAPCRAFT_PART_INSTALL}/
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
-        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/bouncer.VERSION
+        # git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/bouncer.VERSION

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -189,8 +189,8 @@ apps:
       command: bin/print-versions
     cosign:
       command: bin/cosign
-    socket-proxy:
-      command: launch-socket-proxy.sh
+    bouncer:
+      command: launch-bouncer.sh
 parts:
     help:
       plugin: dump
@@ -642,13 +642,13 @@ parts:
         sudo rm /usr/local/bin/go /usr/local/bin/gofmt
         sudo ln -sf /usr/local/go1.14/bin/go /usr/local/bin/go
         sudo ln -sf /usr/local/go1.14/bin/gofmt /usr/local/bin/gofmt
-    socket-proxy:
+    bouncer:
       plugin: cmake
-      source: https://github.com/PelionIoT/socket-proxy.git
+      source: https://github.com/PelionIoT/bouncer.git
       source-type: git
       source-tag: v1.0.2
       override-build: |
         snapcraftctl build
-        install ${SNAPCRAFT_PROJECT_DIR}/files/socket-proxy/scripts/launch-socket-proxy.sh ${SNAPCRAFT_PART_INSTALL}/
+        install ${SNAPCRAFT_PROJECT_DIR}/files/bouncer/scripts/launch-bouncer.sh ${SNAPCRAFT_PART_INSTALL}/
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
-        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/socket-proxy.VERSION
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/bouncer.VERSION

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -646,7 +646,7 @@ parts:
       plugin: cmake
       source: https://github.com/PelionIoT/bouncer.git
       source-type: git
-      source-tag: v1.0.2
+      source-tag: v1.0.3
       override-build: |
         snapcraftctl build
         install ${SNAPCRAFT_PROJECT_DIR}/files/bouncer/scripts/launch-bouncer.sh ${SNAPCRAFT_PART_INSTALL}/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -189,6 +189,8 @@ apps:
       command: bin/print-versions
     cosign:
       command: bin/cosign
+    socket-proxy:
+      command: launch-socket-proxy.sh
 parts:
     help:
       plugin: dump
@@ -500,6 +502,7 @@ parts:
       install-via: prefix
       build-packages:
         - libtool
+      configflags: [--enable-versioned-symbols]
     docker-wrapper-scripts:
       plugin: dump
       source: files/docker/
@@ -639,3 +642,13 @@ parts:
         sudo rm /usr/local/bin/go /usr/local/bin/gofmt
         sudo ln -sf /usr/local/go1.14/bin/go /usr/local/bin/go
         sudo ln -sf /usr/local/go1.14/bin/gofmt /usr/local/bin/gofmt
+    socket-proxy:
+      plugin: cmake
+      source: https://github.com/PelionIoT/socket-proxy.git
+      source-type: git
+      source-tag: v1.0.2
+      override-build: |
+        snapcraftctl build
+        install ${SNAPCRAFT_PROJECT_DIR}/files/socket-proxy/scripts/launch-socket-proxy.sh ${SNAPCRAFT_PART_INSTALL}/
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/socket-proxy.VERSION


### PR DESCRIPTION
Socket proxy is part of the container signing feature.  It will proxy
the docker unix socket and eventually filter messages.