### PR TITLE
move docker runtime files to tmpfs

### DIFF
--- a/files/docker/bin/dockerd-wrapper
+++ b/files/docker/bin/dockerd-wrapper
@@ -5,6 +5,8 @@ default_socket_group=docker
 
 aa_profile_reloaded="$SNAP_COMMON/profile_reloaded"
 
+runtime_path_prefix="/run/snap.$SNAP_INSTANCE_NAME"
+
 workaround_apparmor_profile_reload() {
     #https://github.com/docker/docker-snap/issues/4
     if [ ! -f "$aa_profile_refreshed" ]; then
@@ -60,8 +62,8 @@ if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
     cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
 fi
 
-# use SNAP_COMMON for most "data" bits
-mkdir -p "$SNAP_COMMON/var/run/docker"
+# ensure the directory containing runtime state exists
+mkdir -p "$runtime_path_prefix/var/run/docker"
 
 # ensure the layouts dir for /etc/docker exists
 mkdir -p "$SNAP_DATA/etc/docker"
@@ -80,10 +82,10 @@ fi
 
 exec dockerd \
 	-G $default_socket_group \
-	--exec-root="$SNAP_COMMON/var/run/docker" \
-	--data-root="$SNAP_COMMON/var/lib/docker" \
-	--pidfile="$SNAP_COMMON/var/run/docker.pid" \
-	--host="unix://$SNAP_COMMON/var/run/docker.sock" \
+	--exec-root="$runtime_path_prefix/var/run/docker" \
+	--data-root="$runtime_path_prefix/var/lib/docker" \
+	--pidfile="$runtime_path_prefix/var/run/docker.pid" \
+	--host="unix://$runtime_path_prefix/var/run/docker.sock" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
 	$BRIDGEOPTS \
 	"$@"

--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+runtime_path_prefix="/run/snap.${SNAP_INSTANCE_NAME}"
+
 DEVICE_ID=`jq -r .deviceID ${SNAP_DATA}/userdata/edge_gw_identity/identity.json`
 if [ $? -ne 0 ]; then
     echo "Unable to extract device ID from identity.json"
@@ -75,6 +77,6 @@ exec ${SNAP}/wigwag/system/bin/kubelet \
     --network-plugin=cni \
     --node-status-update-frequency=150s \
     --register-node=true \
-    --docker-endpoint=unix://${SNAP_COMMON}/var/run/docker.sock \
+    --docker-endpoint=unix://$runtime_path_prefix/var/run/docker.sock \
     --v 2 \
     $NODE_IP_OPTION

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,7 +67,7 @@ apps:
         NODE_PATH: $SNAP/wigwag/devicejs-core-modules/node_modules
         LD_LIBRARY_PATH: $SNAP/wigwag/system/lib
         PATH: $PATH:$SNAP/wigwag/system/bin
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       plugs: [network, ssh-keys, ssh-public-keys, network-bind, network-control, network-observe, snapd-control, shutdown, network-manager, modem-manager, log-observe]
     edge-core:
       restart-delay: 5s
@@ -75,7 +75,7 @@ apps:
       command: launch-edge-core.sh
       daemon: simple
       environment:
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       plugs:
         - docker
         - hardware-observe
@@ -136,7 +136,7 @@ apps:
       command: launch-kubelet.sh
       daemon: simple
       environment:
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       plugs:
         - bluetooth-control
         - docker
@@ -162,7 +162,7 @@ apps:
         GIT_CONFIG_NOSYSTEM: "true"
         GIT_EXEC_PATH: $SNAP/libexec/git-core
         GIT_TEXTDOMAINDIR: $SNAP/usr/share/locale
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       completer: bin/docker-completion.sh
       plugs:
         - docker-cli
@@ -173,7 +173,7 @@ apps:
       command: bin/dockerd-wrapper
       daemon: simple
       environment:
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       plugs:
         - network-bind
         - firewall-control


### PR DESCRIPTION
This fixes an issue where the docker.pid file is left behind after
a sudden power loss.

If the docker.pid file exists when dockerd starts, dockerd first
checks to see if there is a running process with a pid that matches
the contents of the pid file, and if so, refuses to start.

The problem is intermittent because sometimes there isn't a process
with a matching pid, in which case docker happily deletes the stale
pid file and boots normally.