### PR TITLE
fix bouncer version file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -647,8 +647,11 @@ parts:
       source: https://github.com/PelionIoT/bouncer.git
       source-type: git
       source-tag: v1.0.3
+      override-pull: |
+        snapcraftctl pull
+        git describe --tags > bouncer.VERSION
       override-build: |
         snapcraftctl build
         install ${SNAPCRAFT_PROJECT_DIR}/files/bouncer/scripts/launch-bouncer.sh ${SNAPCRAFT_PART_INSTALL}/
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
-        # git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/bouncer.VERSION
+        install -m 0644 ${SNAPCRAFT_PART_SRC}/bouncer.VERSION ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -647,11 +647,8 @@ parts:
       source: https://github.com/PelionIoT/bouncer.git
       source-type: git
       source-tag: v1.0.3
-      override-pull: |
-        snapcraftctl pull
-        git describe --tags > bouncer.VERSION
       override-build: |
         snapcraftctl build
         install ${SNAPCRAFT_PROJECT_DIR}/files/bouncer/scripts/launch-bouncer.sh ${SNAPCRAFT_PART_INSTALL}/
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
-        install -m 0644 ${SNAPCRAFT_PART_SRC}/bouncer.VERSION ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/
+        git -C ${SNAPCRAFT_PART_SRC} describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/bouncer.VERSION


### PR DESCRIPTION
the snapcraft cmake plugin doesn't copy the .git directory from
the download folder into the build directory, so git commands
may not work in the build phase.

the command does seem to work in some environments because git
"falls up" the directory structure looking for a containing
.git folder, usually finding the .git folder of snap-pelion-edge,
which obviously contains the wrong version for the part.