### PR TITLE
Fix socket paths to match newly moved paths

### DIFF
--- a/files/bouncer/scripts/launch-bouncer.sh
+++ b/files/bouncer/scripts/launch-bouncer.sh
@@ -18,4 +18,4 @@
 # ----------------------------------------------------------------------------
 
 # add ${SNAP} to PATH edge-core can run the factory reset script: edge-core-factory-reset
-exec env PATH=${PATH}:${SNAP} ${SNAP}/bin/bouncer ${SNAP_COMMON}/var/run/docker-proxy.sock ${SNAP_COMMON}/var/run/docker.sock
+exec env PATH=${PATH}:${SNAP} ${SNAP}/bin/bouncer /run/snap.${SNAP_INSTANCE_NAME}/var/run/docker-proxy.sock /run/snap.${SNAP_INSTANCE_NAME}/var/run/docker.sock


### PR DESCRIPTION
Docker sock was moved to /run/snap.snap-pelion-edge/var/run/.  We need
to update this script to use the same.