### PR TITLE
lock yq to version 3.4.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -378,6 +378,7 @@ parts:
       build-environment:
         - GOFLAGS:  "$GOFLAGS -modcacherw"
       source: https://github.com/mikefarah/yq.git
+      source-tag: 3.4.1
       go-importpath: github.com/mikefarah/yq
     maestro:
       plugin: make


### PR DESCRIPTION
This fixes fix yq failure to read the maestro yaml
config file on startup.

This commit fixes these log errors:
maestro[]: Error: unknown command "r" for "yq"
maestro[]: Run 'yq --help' for usage.
maestro[]: Error: unknown command "r" for "yq"
maestro[]: Run 'yq --help' for usage.

The yq version was not version-locked and yq version 4.0
is a major breaking change from previous versions:
https://github.com/mikefarah/yq/releases/tag/4.0.0-alpha1