### PR TITLE
v2.3.1-1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Copy mbed_cloud_dev_credentials.c
+        env:
+          MBED_CLOUD_DEV_CREDENTIALS: ${{ secrets.MBED_CLOUD_DEV_CREDENTIALS_C_RYAN }}
+        run: |
+          echo "$MBED_CLOUD_DEV_CREDENTIALS" > mbed_cloud_dev_credentials.c
+      - name: Copy update_default_resources.c
+        env:
+          UPDATE_DEFAULT_RESOURCES: ${{ secrets.UPDATE_DEFAULT_RESOURCES_C_RYAN }}
+        run: |
+          echo "$UPDATE_DEFAULT_RESOURCES" > update_default_resources.c
+      - name: Build Docker image
+        run: |
+          docker build --no-cache -f Dockerfile --label snapcore/snapcraft --tag ${USER}/snapcraft:latest .
+      - name: Build snap
+        run: |
+          docker run --rm -v "$PWD":/build -w /build ${USER}/snapcraft:latest bash -c "sudo apt-get update && snapcraft --debug"

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -1,0 +1,22 @@
+name: Check PR Base
+on:
+  pull_request:
+    types: [opened, edited]
+jobs:
+  check-pr-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject PR due to incorrect base
+        if: ( !(github.base_ref == 'master' && github.head_ref == 'dev') && github.base_ref != 'dev') && (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.base.ref))
+        uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          event: REQUEST_CHANGES
+          body: 'Please change your PR base to dev branch.'
+      - name: Approve PR because it's based against dev branch
+        if: ((github.base_ref == 'master' && github.head_ref == 'dev') || github.base_ref == 'dev') && github.event.changes.base && github.event.changes.base.ref.from != 'dev'
+        uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          event: APPROVE
+          body: 'Your PR is based against the dev branch.  Looks good.'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,14 @@ RUN apt-get update && apt-get install -y \
 # Install Go
 # Download the go binary package, unpack it in the proper place,
 # and link the go binaries to make them available to snapcraft
+
 RUN curl -L https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz | tar -xz && \
-    mv go /usr/local && \
-    ln -sf /usr/local/go/bin/go /usr/local/bin/go && \
-    ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+    mv go /usr/local/go1.14 && \
+    ln -sf /usr/local/go1.14/bin/go /usr/local/bin/go && \
+    ln -sf /usr/local/go1.14/bin/gofmt /usr/local/bin/gofmt
+
+RUN curl -L https://golang.org/dl/go1.17.linux-amd64.tar.gz | tar -xz && \
+    mv go /usr/local/go1.17
 
 # Install the script that sets up the user environment
 # and runs CMD as the current user instead of as root

--- a/files/docker/bin/dockerd-wrapper
+++ b/files/docker/bin/dockerd-wrapper
@@ -5,6 +5,8 @@ default_socket_group=docker
 
 aa_profile_reloaded="$SNAP_COMMON/profile_reloaded"
 
+runtime_path_prefix="/run/snap.$SNAP_INSTANCE_NAME"
+
 workaround_apparmor_profile_reload() {
     #https://github.com/docker/docker-snap/issues/4
     if [ ! -f "$aa_profile_refreshed" ]; then
@@ -60,8 +62,8 @@ if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
     cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
 fi
 
-# use SNAP_COMMON for most "data" bits
-mkdir -p "$SNAP_COMMON/var/run/docker"
+# ensure the directory containing runtime state exists
+mkdir -p "$runtime_path_prefix/var/run/docker"
 
 # ensure the layouts dir for /etc/docker exists
 mkdir -p "$SNAP_DATA/etc/docker"
@@ -80,10 +82,10 @@ fi
 
 exec dockerd \
 	-G $default_socket_group \
-	--exec-root="$SNAP_COMMON/var/run/docker" \
-	--data-root="$SNAP_COMMON/var/lib/docker" \
-	--pidfile="$SNAP_COMMON/var/run/docker.pid" \
-	--host="unix://$SNAP_COMMON/var/run/docker.sock" \
+	--exec-root="$runtime_path_prefix/var/run/docker" \
+	--data-root="$runtime_path_prefix/var/lib/docker" \
+	--pidfile="$runtime_path_prefix/var/run/docker.pid" \
+	--host="unix://$runtime_path_prefix/var/run/docker.sock" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
 	$BRIDGEOPTS \
 	"$@"

--- a/files/fluent-bit/config/fluent-bit.conf
+++ b/files/fluent-bit/config/fluent-bit.conf
@@ -1,7 +1,7 @@
 [SERVICE]
     Flush     5
     Daemon    off
-    Log_Level warning
+    Log_Level warn
 
 [FILTER]
     Name record_modifier
@@ -49,7 +49,7 @@
 [INPUT]
     Name            systemd
     Tag             ${edge_core_tag}
-    Systemd_Filter  _SYSTEMD_UNIT=edge-core.service
+    Systemd_Filter  _SYSTEMD_UNIT=snap.${SNAP_INSTANCE_NAME}.edge-core.service
 [FILTER]
     Name record_modifier
     Match ${edge_core_tag}
@@ -98,7 +98,7 @@
 [INPUT]
     Name            systemd
     Tag             ${edge_proxy_tag}
-    Systemd_Filter  _SYSTEMD_UNIT=edge-proxy.service
+    Systemd_Filter  _SYSTEMD_UNIT=snap.${SNAP_INSTANCE_NAME}.edge-proxy.service
 [FILTER]
     Name record_modifier
     Match ${edge_proxy_tag}
@@ -118,7 +118,7 @@
 [INPUT]
     Name            systemd
     Tag             ${relay_term_tag}
-    Systemd_Filter  _SYSTEMD_UNIT=pelion-relay-term.service
+    Systemd_Filter  _SYSTEMD_UNIT=snap.${SNAP_INSTANCE_NAME}.pelion-relay-term.service
 [FILTER]
     Name record_modifier 
     Match ${relay_term_tag}
@@ -138,7 +138,7 @@
 [INPUT]
     Name            systemd
     Tag             ${maestro_tag}
-    Systemd_Filter  _SYSTEMD_UNIT=maestro.service
+    Systemd_Filter  _SYSTEMD_UNIT=snap.${SNAP_INSTANCE_NAME}.maestro.service
 [FILTER]
     Name record_modifier
     Match ${maestro_tag}
@@ -158,7 +158,7 @@
 [INPUT]
     Name            systemd
     Tag             ${kubelet_tag}
-    Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+    Systemd_Filter  _SYSTEMD_UNIT=snap.${SNAP_INSTANCE_NAME}.kubelet.service
 [FILTER]
     Name record_modifier
     Match ${kubelet_tag}
@@ -178,7 +178,7 @@
 [INPUT]
     Name            systemd
     Tag             ${docker}
-    Systemd_Filter  _SYSTEMD_UNIT=docker.service
+    Systemd_Filter  _SYSTEMD_UNIT=snap.${SNAP_INSTANCE_NAME}.docker.service
 [FILTER]
     Name record_modifier
     Match ${docker_tag}
@@ -198,7 +198,7 @@
 [INPUT]
     Name            systemd
     Tag             ${wait-for-pelion-identity_tag}
-    Systemd_Filter  _SYSTEMD_UNIT=wait-for-pelion-identity.service
+    Systemd_Filter  _SYSTEMD_UNIT=snap.${SNAP_INSTANCE_NAME}.wait-for-pelion-identity.service
 [FILTER]
     Name record_modifier
     Match ${wait-for-pelion-identity_tag}

--- a/files/fluent-bit/config/fluent-bit.conf
+++ b/files/fluent-bit/config/fluent-bit.conf
@@ -9,41 +9,6 @@
     Record app_name fluentbit
     Record level INFO
 
-@SET cpu_tag=cpu
-
-[INPUT]
-    Name cpu
-    Tag  ${cpu_tag}
-[FILTER]
-    Name record_modifier
-    Match ${cpu_tag}
-    Record type ${cpu_tag}
-[FILTER]
-    Name nest
-    Match ${cpu_tag}
-    Operation nest
-    Wildcard user_p*
-    Wildcard system_p*
-    Wildcard cpu*
-    Nest_under message_json
-
-@SET mem_tag=memory
-
-[INPUT]
-    Name   mem
-    Tag    ${mem_tag}
-[FILTER]
-    Name record_modifier
-    Match ${mem_tag}
-    Record type ${mem_tag}
-[FILTER]
-    Name nest
-    Match ${mem_tag}
-    Operation nest
-    Wildcard Mem.*
-    Wildcard Swap.*
-    Nest_under message_json
-
 @SET edge_core_tag=edge-core
 
 [INPUT]

--- a/files/fluent-bit/config/fluent-bit.conf
+++ b/files/fluent-bit/config/fluent-bit.conf
@@ -1,0 +1,225 @@
+[SERVICE]
+    Flush     5
+    Daemon    off
+    Log_Level warning
+
+[FILTER]
+    Name record_modifier
+    Match *
+    Record app_name fluentbit
+    Record level INFO
+
+@SET cpu_tag=cpu
+
+[INPUT]
+    Name cpu
+    Tag  ${cpu_tag}
+[FILTER]
+    Name record_modifier
+    Match ${cpu_tag}
+    Record type ${cpu_tag}
+[FILTER]
+    Name nest
+    Match ${cpu_tag}
+    Operation nest
+    Wildcard user_p*
+    Wildcard system_p*
+    Wildcard cpu*
+    Nest_under message_json
+
+@SET mem_tag=memory
+
+[INPUT]
+    Name   mem
+    Tag    ${mem_tag}
+[FILTER]
+    Name record_modifier
+    Match ${mem_tag}
+    Record type ${mem_tag}
+[FILTER]
+    Name nest
+    Match ${mem_tag}
+    Operation nest
+    Wildcard Mem.*
+    Wildcard Swap.*
+    Nest_under message_json
+
+@SET edge_core_tag=edge-core
+
+[INPUT]
+    Name            systemd
+    Tag             ${edge_core_tag}
+    Systemd_Filter  _SYSTEMD_UNIT=edge-core.service
+[FILTER]
+    Name record_modifier
+    Match ${edge_core_tag}
+    Whitelist_key MESSAGE
+    Whitelist_key level
+    Record app_name edge-core
+    Record type systemd
+[FILTER]
+    Name grep
+    Match ${edge_core_tag}
+    Exclude MESSAGE \[DBG
+[FILTER]
+    Name    modify
+    Match   ${edge_core_tag}
+    Condition Key_value_matches  MESSAGE \[DBG
+    Set level DEBUG
+[FILTER]
+    Name    modify
+    Match   ${edge_core_tag}
+    Condition Key_value_matches  MESSAGE \[INFO\]
+    Set level INFO
+[FILTER]
+    Name    modify
+    Match   ${edge_core_tag}
+    Condition Key_value_matches  MESSAGE \[WARN\]
+    Set level WARNING
+[FILTER]
+    Name    modify
+    Match   ${edge_core_tag}
+    Condition Key_value_matches  MESSAGE \[ERR
+    Set level ERROR
+[FILTER]
+    Name    modify
+    Match   ${edge_core_tag}
+    Condition Key_value_does_not_match  MESSAGE \[DBG|\[INFO\]|\[WARN\]|\[ERR
+    Set level TRACE
+[FILTER]
+    Name nest
+    Match ${edge_core_tag}
+    Operation nest
+    Wildcard MESSAGE*
+    Nest_under message_json
+    
+@SET edge_proxy_tag=edge-proxy
+
+[INPUT]
+    Name            systemd
+    Tag             ${edge_proxy_tag}
+    Systemd_Filter  _SYSTEMD_UNIT=edge-proxy.service
+[FILTER]
+    Name record_modifier
+    Match ${edge_proxy_tag}
+    Whitelist_key MESSAGE
+    Whitelist_key level
+    Record app_name edge-proxy
+    Record type systemd
+[FILTER]
+    Name nest
+    Match ${edge_proxy_tag}
+    Operation nest
+    Wildcard MESSAGE*
+    Nest_under message_json
+
+@SET relay_term_tag=relay-term
+
+[INPUT]
+    Name            systemd
+    Tag             ${relay_term_tag}
+    Systemd_Filter  _SYSTEMD_UNIT=pelion-relay-term.service
+[FILTER]
+    Name record_modifier 
+    Match ${relay_term_tag}
+    Whitelist_key MESSAGE
+    Whitelist_key level
+    Record app_name relay-term
+    Record type systemd
+[FILTER]
+    Name nest
+    Match ${relay_term_tag}
+    Operation nest
+    Wildcard MESSAGE*
+    Nest_under message_json
+
+@SET maestro_tag=maestro
+
+[INPUT]
+    Name            systemd
+    Tag             ${maestro_tag}
+    Systemd_Filter  _SYSTEMD_UNIT=maestro.service
+[FILTER]
+    Name record_modifier
+    Match ${maestro_tag}
+    Whitelist_key MESSAGE
+    Whitelist_key level
+    Record app_name maestro
+    Record type systemd
+[FILTER]
+    Name nest
+    Match ${maestro_tag}
+    Operation nest
+    Wildcard MESSAGE*
+    Nest_under message_json
+
+@SET kubelet_tag=kubelet
+
+[INPUT]
+    Name            systemd
+    Tag             ${kubelet_tag}
+    Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+[FILTER]
+    Name record_modifier
+    Match ${kubelet_tag}
+    Whitelist_key MESSAGE
+    Whitelist_key level
+    Record app_name kubelet
+    Record type systemd
+[FILTER]
+    Name nest
+    Match ${kubelet_tag}
+    Operation nest
+    Wildcard MESSAGE*
+    Nest_under message_json
+
+@SET docker_tag=docker
+
+[INPUT]
+    Name            systemd
+    Tag             ${docker}
+    Systemd_Filter  _SYSTEMD_UNIT=docker.service
+[FILTER]
+    Name record_modifier
+    Match ${docker_tag}
+    Whitelist_key MESSAGE
+    Whitelist_key level
+    Record app_name docker
+    Record type systemd
+[FILTER]
+    Name nest
+    Match ${docker_tag}
+    Operation nest
+    Wildcard MESSAGE*
+    Nest_under message_json
+
+@SET wait-for-pelion-identity_tag=wait-for-pelion-identity
+
+[INPUT]
+    Name            systemd
+    Tag             ${wait-for-pelion-identity_tag}
+    Systemd_Filter  _SYSTEMD_UNIT=wait-for-pelion-identity.service
+[FILTER]
+    Name record_modifier
+    Match ${wait-for-pelion-identity_tag}
+    Whitelist_key MESSAGE
+    Whitelist_key level
+    Record app_name wait-for-pelion-identity
+    Record type systemd
+[FILTER]
+    Name nest
+    Match ${wait-for-pelion-identity_tag}
+    Operation nest
+    Wildcard MESSAGE*
+    Nest_under message_json
+
+[OUTPUT]
+    Name  http
+    Match *
+    Host  gateways.local
+    Port  8080
+    URI   /v3/device-logs
+    Format json
+    json_date_format iso8601
+    json_date_key date_time
+    Retry_Limit     2

--- a/files/fluent-bit/config/fluent-bit.conf
+++ b/files/fluent-bit/config/fluent-bit.conf
@@ -188,3 +188,9 @@
     json_date_format iso8601
     json_date_key date_time
     Retry_Limit     2
+[FILTER]
+    Name grep
+    Match *
+    Exclude level DEBUG
+    Exclude level TRACE
+    Exclude level INFO

--- a/files/fluent-bit/scripts/launch-fluent-bit.sh
+++ b/files/fluent-bit/scripts/launch-fluent-bit.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ! -f ${SNAP_DATA}/userdata/edge_gw_identity/identity.json ]; then
+    echo "identity.json does not exist"
+    exit 1
+fi
+
+if [ ! -f "$SNAP_DATA/fluent-bit.conf" ]; then
+    cp "$SNAP/fluent-bit.conf" "$SNAP_DATA/fluent-bit.conf"
+fi
+
+exec ${SNAP}/wigwag/system/bin/fluent-bit -c $SNAP_DATA/fluent-bit.conf

--- a/files/help/help.md
+++ b/files/help/help.md
@@ -1,4 +1,6 @@
 = Pelion Edge =
+* version
+    Prints the version of each pelion-edge component.
 
 == edge-core ==
 

--- a/files/kubelet/scripts/launch-kubelet.sh
+++ b/files/kubelet/scripts/launch-kubelet.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+runtime_path_prefix="/run/snap.${SNAP_INSTANCE_NAME}"
+
 DEVICE_ID=`jq -r .deviceID ${SNAP_DATA}/userdata/edge_gw_identity/identity.json`
 if [ $? -ne 0 ]; then
     echo "Unable to extract device ID from identity.json"
@@ -75,6 +77,6 @@ exec ${SNAP}/wigwag/system/bin/kubelet \
     --network-plugin=cni \
     --node-status-update-frequency=150s \
     --register-node=true \
-    --docker-endpoint=unix://${SNAP_COMMON}/var/run/docker.sock \
+    --docker-endpoint=unix://$runtime_path_prefix/var/run/docker.sock \
     --v 2 \
     $NODE_IP_OPTION

--- a/files/maestro/config/maestro-config-dell5000.yaml
+++ b/files/maestro/config/maestro-config-dell5000.yaml
@@ -45,7 +45,7 @@ gateway_capabilities:
   gateway_resources:
   - name: "urn:fid:pelion.com:log:1.0.0"
     enable: true
-    config_filepath: "{{SNAP_DATA}}/maestro-config.yaml"
+    config_filepath: "{{SNAP_DATA}}/fluent-bit.conf"
   - name: "urn:fid:pelion.com:terminal:1.0.0"
     enable: true
     config_filepath: "{{SNAP_DATA}}/wigwag/etc/relayterm-config.json"

--- a/files/maestro/config/maestro-config-dell5000.yaml
+++ b/files/maestro/config/maestro-config-dell5000.yaml
@@ -73,20 +73,6 @@ mdns:
      text:
       - "wwid={{ARCH_SERIAL_NUMBER}}"
      hostname: "{{ARCH_SERIAL_NUMBER}}"
-symphony:
-# symphony system management APIs
-    # defaults to 10:
-    disable_sys_stats: true
-    sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
-    sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
-    #client_cert: "{{ARCH_CLIENT_CERT_PEM}}"
-    #client_key: "{{ARCH_CLIENT_KEY_PEM}}"
-    no_tls: true
-    host: "gateways.local"
-    url_logs: "http://gateways.local:8080/relay-logs/logs"
-    url_stats: "http://gateways.local:8080/relay-stats/stats_obj"
-    send_time_threshold: 120000       # set the send time threshold to 2 minutes
-    # port: "{{ARCH_RELAY_SERVICES_PORT}}"
 targets:
    - file: "{{SNAP_DATA}}/userdata/maestro.log"
      rotate:
@@ -106,19 +92,6 @@ targets:
        - levels: error
          format_pre: "\u001B[31m"    # red
          format_post: "\u001B[39m"
-   - name: "toCloud"  # this is a special target for sending to the cloud. It must send as a JSON
-     format_time: "\"timestamp\":%ld%03d, "
-     format_level: "\"level\":\"%s\", "
-     format_tag: "\"tag\":\"%s\", "
-     format_origin: "\"origin\":\"%s\", "
-     format_pre_msg: "\"text\":\""
-     format_post: "\"},"
-     flag_json_escape_strings: true
-     filters:
-       - levels: warn
-         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
-       - levels: error
-         format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
 static_file_generators:
    - name: "devicedb"
      template_file: "{{SNAP}}/wigwag/etc/templates/template.devicedb.conf"

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -20,7 +20,7 @@ echo -n "pe-utils: "; ${SNAP}/wigwag/pe-utils/identity-tools/developer_identity/
 echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
 echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
 echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
-echo -n "maestro-shell: "; ${SNAP}/wigwag/system/bin/maestro-shell -h | grep ver
+echo -n "maestro-shell: "; cat ${SNAP}/wigwag/etc/maestro-shell.VERSION
 echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
 echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version
 if [ "${SHOW_DOCKER}" = "true" ]; then

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -22,7 +22,7 @@ echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
 echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
 echo -n "maestro-shell: "; cat ${SNAP}/wigwag/etc/maestro-shell.VERSION
 echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
-echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version
+echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version | cut -d' ' -f2
 if [ "${SHOW_DOCKER}" = "true" ]; then
 	echo -n "docker: "; ${SNAP}/bin/docker --version
 	echo -n "docker-runc: "; ${SNAP}/bin/docker-runc --version

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -19,7 +19,7 @@ echo -n "relay-term: "; cat ${SNAP}/wigwag/etc/edge-node-modules.VERSION
 echo -n "pe-utils: "; ${SNAP}/wigwag/pe-utils/identity-tools/developer_identity/create-dev-identity.sh -V
 echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
 echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
-echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
+echo -n "maestro: "; cat ${SNAP}/wigwag/etc/maestro.VERSION
 echo -n "maestro-shell: "; cat ${SNAP}/wigwag/etc/maestro-shell.VERSION
 echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
 echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version | cut -d' ' -f2

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+THISFILE=$(basename $0)
+if [[ -e "${SNAP_DATA}/$THISFILE" ]] && [[ "$0" != "${SNAP_DATA}/$THISFILE" ]]; then
+    exec ${SNAP_DATA}/$THISFILE $@
+fi
+
+SHOW_DOCKER="false"
+
+while [ -n "$1" ]; do
+	case "$1" in
+	--all) SHOW_DOCKER="true";;
+	*) echo "$1 not supported";;
+	esac
+	shift
+done
+
+echo "relay-term: unsupported"
+echo -n "pe-utils: "; ${SNAP}/wigwag/pe-utils/identity-tools/developer_identity/create-dev-identity.sh -V
+echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
+echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
+echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
+echo -n "maestro-shell: "; ${SNAP}/wigwag/system/bin/maestro-shell -h | grep ver
+echo "edge-proxy: unsupported"
+echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version
+if [ "${SHOW_DOCKER}" = "true" ]; then
+	echo -n "docker: "; ${SNAP}/bin/docker --version
+	echo -n "docker-runc: "; ${SNAP}/bin/docker-runc --version
+	echo -n "docker-containerd: "; ${SNAP}/bin/docker-containerd --version
+	echo -n "docker-init: "; ${SNAP}/bin/docker-init --version
+fi

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -21,7 +21,7 @@ echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
 echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version
 echo -n "maestro: "; ${SNAP}/wigwag/system/bin/maestro --version
 echo -n "maestro-shell: "; ${SNAP}/wigwag/system/bin/maestro-shell -h | grep ver
-echo "edge-proxy: unsupported"
+echo -n "edge-proxy: "; cat ${SNAP}/wigwag/etc/edge-proxy.VERSION
 echo -n "kubelet: "; ${SNAP}/wigwag/system/bin/kubelet --version
 if [ "${SHOW_DOCKER}" = "true" ]; then
 	echo -n "docker: "; ${SNAP}/bin/docker --version

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -15,7 +15,7 @@ while [ -n "$1" ]; do
 	shift
 done
 
-echo "relay-term: unsupported"
+echo -n "relay-term: "; cat ${SNAP}/wigwag/etc/edge-node-modules.VERSION
 echo -n "pe-utils: "; ${SNAP}/wigwag/pe-utils/identity-tools/developer_identity/create-dev-identity.sh -V
 echo -n "edge-core: "; ${SNAP}/wigwag/mbed/edge-core --version
 echo -n "devicedb: "; ${SNAP}/wigwag/system/bin/devicedb -version

--- a/files/version/print-versions.sh
+++ b/files/version/print-versions.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-THISFILE=$(basename $0)
-if [[ -e "${SNAP_DATA}/$THISFILE" ]] && [[ "$0" != "${SNAP_DATA}/$THISFILE" ]]; then
-    exec ${SNAP_DATA}/$THISFILE $@
-fi
-
 SHOW_DOCKER="false"
 
 while [ -n "$1" ]; do

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -68,6 +68,10 @@ if [[ -z $(snapctl get kubelet.offline-mode) ]]; then
     snapctl set kubelet.offline-mode=true
 fi
 
+if [[ -z $(snapctl get kubelet.container-signing) ]]; then
+    snapctl set kubelet.container-signing=false
+fi
+
 if [[ -z $(snapctl get docker.bridge) ]]; then
     snapctl set docker.bridge=enable
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -76,6 +76,10 @@ if [[ -z $(snapctl get edge-core.refresh-timeout) ]]; then
     snapctl set edge-core.refresh-timeout=300
 fi
 
+if [[ -z $(snapctl get edge-core.network-wait-timeout) ]]; then
+    snapctl set edge-core.network-wait-timeout=1200
+fi
+
 if [[ -z $(snapctl get edge-core.proxy) ]]; then
     snapctl set edge-core.proxy=""
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -399,6 +399,8 @@ parts:
         done
         # fixup the SNAP and SNAP_DATA variables in the config files based on the snap name
         sed -i "s!/snap/pelion-edge!/snap/${SNAPCRAFT_PROJECT_NAME}!" ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates/*.yaml
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/maestro.VERSION
     cni:
       plugin: go
       source: https://github.com/containernetworking/plugins.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -625,6 +625,8 @@ parts:
       source: https://github.com/sigstore/cosign.git
       go-importpath: github.com/sigstore/cosign/cmd/cosign
       source-commit: 33973d078170f586cf27f2cc464844b3f1fa1abb
+      build-environment:
+        - GOFLAGS:  "$GOFLAGS -modcacherw"
       override-build: |
         export GOROOT=/usr/local/go1.17
         export PATH="$GOROOT/bin:$PATH"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -179,6 +179,8 @@ apps:
         - docker-daemon
     docker-help:
       command: bin/help
+    version:
+      command: bin/print-versions
 parts:
     help:
       plugin: dump
@@ -186,6 +188,14 @@ parts:
       override-build: |
         snapcraftctl build
         chmod a+x bin/print-help
+    version:
+      plugin: dump
+      source: files/version/
+      override-build: |
+        snapcraftctl build
+        chmod a+x print-versions.sh
+      organize:
+        print-versions.sh: bin/print-versions
     platform-version:
       plugin: dump
       source: files/platform-version/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: pelion-edge
 base: core
-version: "2.3.0-1"
+version: "2.3.1-1"
 summary: Pelion Edge
 description: Pelion Edge
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -322,6 +322,10 @@ parts:
       source: https://github.com/PelionIoT/edge-node-modules.git
       source-commit: bcafcba2e6602ef486a8975c67a1df3872289499
       source-subdir: relay-term
+      override-build: |
+        snapcraftctl build
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/edge-node-modules.VERSION
       organize:
         'config': wigwag/wigwag-core-modules/relay-term/config
         'node_modules': wigwag/wigwag-core-modules/relay-term/node_modules

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,6 +97,12 @@ apps:
       restart-condition: always
       daemon: simple
       plugs: [hardware-observe, network-bind, network-control, network-observe, snapd-control]
+    fluent-bit:
+      restart-delay: 5s
+      restart-condition: always
+      command: launch-fluent-bit.sh
+      daemon: simple
+      plugs: [network, network-bind, system-files-logs, log-observe]
     maestro:
       command: launch-maestro.sh
       environment:
@@ -402,6 +408,26 @@ parts:
         sed -i "s!/snap/pelion-edge!/snap/${SNAPCRAFT_PROJECT_NAME}!" ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates/*.yaml
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
         git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/maestro.VERSION
+    fluent-bit:
+      plugin: cmake
+      source: https://github.com/fluent/fluent-bit.git
+      source-tag: v1.7.9
+      build-packages:
+        - libsystemd-dev
+        - flex
+        - bison
+      configflags:
+        - -DFLB_JEMALLOC=On
+        - -DFLB_SHARED_LIB=Off
+        - -DFLB_EXAMPLES=Off
+        - -DFLB_IN_SYSTEMD=On
+      override-build: |
+        snapcraftctl build
+        install ${SNAPCRAFT_PROJECT_DIR}/files/fluent-bit/config/fluent-bit.conf ${SNAPCRAFT_PART_INSTALL}/
+        install ${SNAPCRAFT_PROJECT_DIR}/files/fluent-bit/scripts/launch-fluent-bit.sh ${SNAPCRAFT_PART_INSTALL}/
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
+      organize:
+        bin/fluent-bit: wigwag/system/bin/fluent-bit
     cni:
       plugin: go
       source: https://github.com/containernetworking/plugins.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -187,6 +187,8 @@ apps:
       command: bin/help
     version:
       command: bin/print-versions
+    cosign:
+      command: bin/cosign
 parts:
     help:
       plugin: dump
@@ -618,3 +620,20 @@ parts:
         'bin/tini-static': bin/docker-init
       prime:
         - bin/docker-init
+    cosign:
+      plugin: go
+      source: https://github.com/sigstore/cosign.git
+      go-importpath: github.com/sigstore/cosign/cmd/cosign
+      source-commit: 33973d078170f586cf27f2cc464844b3f1fa1abb
+      override-build: |
+        export GOROOT=/usr/local/go1.17
+        export PATH="$GOROOT/bin:$PATH"
+        echo Hacking the go version
+        sudo rm /usr/local/bin/go /usr/local/bin/gofmt
+        sudo ln -sf /usr/local/go1.17/bin/go /usr/local/bin/go
+        sudo ln -sf /usr/local/go1.17/bin/gofmt /usr/local/bin/gofmt
+        snapcraftctl build
+        echo Reverting the go version
+        sudo rm /usr/local/bin/go /usr/local/bin/gofmt
+        sudo ln -sf /usr/local/go1.14/bin/go /usr/local/bin/go
+        sudo ln -sf /usr/local/go1.14/bin/gofmt /usr/local/bin/gofmt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -353,6 +353,8 @@ parts:
         ./build-deps.sh
         # Build maestro-shell
         snapcraftctl build
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/maestro-shell.VERSION
       organize:
         bin/maestro-shell: wigwag/system/bin/maestro-shell
     yq:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -230,6 +230,7 @@ parts:
       source-tag: 0.16.1
       build-environment:
         - COAP_PORT_OVERRIDE_443: "false"
+      stage-packages: [coreutils]
       override-pull: |
         snapcraftctl pull
         # mbed_cloud_dev_credentials.c is required if DEVELOPER_MODE=ON

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -322,7 +322,7 @@ parts:
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
         install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/version.json ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
-        cp -r . ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
+        cp -r identity-tools ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils/
         chmod -R 0755 ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
     maestro-shell:
       plugin: go

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -299,6 +299,8 @@ parts:
         install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
         install ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/config/edge-proxy.conf.json ${SNAPCRAFT_PART_INSTALL}/
         install ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/scripts/launch-edge-proxy.sh ${SNAPCRAFT_PART_INSTALL}/
+        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+        git describe --tags > ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/edge-proxy.VERSION
       organize:
         bin/edge-proxy: wigwag/system/bin/edge-proxy
     devicedb:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,7 +67,7 @@ apps:
         NODE_PATH: $SNAP/wigwag/devicejs-core-modules/node_modules
         LD_LIBRARY_PATH: $SNAP/wigwag/system/lib
         PATH: $PATH:$SNAP/wigwag/system/bin
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       plugs: [network, ssh-keys, ssh-public-keys, network-bind, network-control, network-observe, snapd-control, shutdown, network-manager, modem-manager, log-observe]
     edge-core:
       restart-delay: 5s
@@ -75,7 +75,7 @@ apps:
       command: launch-edge-core.sh
       daemon: simple
       environment:
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       plugs:
         - docker
         - hardware-observe
@@ -136,7 +136,7 @@ apps:
       command: launch-kubelet.sh
       daemon: simple
       environment:
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       plugs:
         - bluetooth-control
         - docker
@@ -162,7 +162,7 @@ apps:
         GIT_CONFIG_NOSYSTEM: "true"
         GIT_EXEC_PATH: $SNAP/libexec/git-core
         GIT_TEXTDOMAINDIR: $SNAP/usr/share/locale
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       completer: bin/docker-completion.sh
       plugs:
         - docker-cli
@@ -173,7 +173,7 @@ apps:
       command: bin/dockerd-wrapper
       daemon: simple
       environment:
-        DOCKER_HOST: unix://$SNAP_COMMON/var/run/docker.sock
+        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
       plugs:
         - network-bind
         - firewall-control


### PR DESCRIPTION
Release candidate from feature branch `v2.3.1-1` to `master`

Not merging `dev` to `master` due to multiple release candidates active on `dev`

Proposed Release Notes:
```
* Feature: Added fluent-bit logging
  * Removed greasego logging from maestro
  * Turn off symphony cloud logging in favor of fluent-bit
* Feature: Cellular connection improvements for snap refresh
* Feature: Added cosign binary to snap
* Feature: Add default value for kubelet.container-signing
* Feature: Move docker runtime files to tmpfs (power loss failure prevention)
* Bug fix: Fix permission denied error when snap cleaning
* Bug fix: Added version commands for each snap component
```