### PR TITLE
Update pe-utils to 2.3.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -608,7 +608,7 @@ parts:
     pe-utils:
       plugin: nil
       source: https://github.com/PelionIoT/pe-utils.git
-      source-tag: 2.2.0
+      source-tag: 2.3.0
       override-build: |
         install -d ${SNAPCRAFT_PART_INSTALL}/edge/etc
         install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/versions.json ${SNAPCRAFT_PART_INSTALL}/edge/
@@ -628,7 +628,7 @@ parts:
     edge-info:
       plugin: dump
       source: https://github.com/PelionIoT/pe-utils.git
-      source-tag: 2.2.0
+      source-tag: 2.3.0
       override-build: |
         install -d "${SNAPCRAFT_PART_INSTALL}/edge"
         git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-info.VERSION"
@@ -644,7 +644,7 @@ parts:
     edge-testnet:
       plugin: dump
       source: https://github.com/PelionIoT/pe-utils.git
-      source-tag: 2.2.0
+      source-tag: 2.3.0
       override-build: |
         install -d "${SNAPCRAFT_PART_INSTALL}/edge"
         git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-testnet.VERSION"


### PR DESCRIPTION
That is edge-info, edge-testnet and so forth...

PR check fails - this is due to some changes in the GitHub runners OR my addition of the snap restart, which it seems GitHub runners cannot tolerate.
- https://github.com/PelionIoT/scripts-internal/pull/76 - once that is merged, we need to re-run the PR check.
