### PR TITLE
Normalise snap/snapcraft.yaml with yq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,3 +177,14 @@ jobs:
       - uses: actions/checkout@v3
       - run: sudo apt-get install yamllint
       - run: yamllint -c lint-config.yaml snap/snapcraft.yaml
+      - name: Check yq compliancy
+        run: |
+          sudo snap install yq
+          yq -r "." <snap/snapcraft.yaml >yqout.yaml
+          if diff -u snap/snapcraft.yaml yqout.yaml
+          then
+            echo "yq compliancy check passed"
+          else
+            echo "yq compliancy check failed"
+            exit 1
+          fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,180 +10,173 @@ architectures:
   - build-on: amd64
     run-on: amd64
 plugs:
-    home:
-      read: all
-    removable-media:
-    snapd:
-        interface: snapd-control
-        refresh-schedule: managed
-    system-files-logs:
-        interface: system-files
-        read:
-          - /run/systemd/journal
-          - /run/systemd/private
-          - /var/lib/snapd/apparmor/profiles
-        write:
-          - /run/systemd/journal
-          - /run/systemd/private
-          - /var/lib/snapd/apparmor/profiles
-          - /var/log
-          - /run/log/journal
-    usr-libexec-kubernetes:
-        interface: system-files
-        read:
-          - /usr/libexec/kubernetes
-          - /usr/libexec/kubernetes/volume
-          - /usr/libexec/kubernetes/volume/exec
-        write:
-          - /usr/libexec/kubernetes
-          - /usr/libexec/kubernetes/volume
-          - /usr/libexec/kubernetes/volume/exec
-    run-docker:
-        interface: system-files
-        read:
-          - /run/docker.pid
-          - /run/containerd/containerd.sock
-        write:
-          - /run/docker.pid
-          - /run/containerd/containerd.sock
-    etc-apparmor-abi:
-        interface: system-files
-        read:
-          - /etc/apparmor.d/abi/2.13
-    edge-tool-files:
-        interface: personal-files
-        read:
-          - $HOME/.mbed_cloud_config.json
-    testnet-credential-files:
-        interface: system-files
-        read:
-          - /usr/bin/credentials/bootstrap.pem
-          - /usr/bin/credentials/device01_cert.pem
-          - /usr/bin/credentials/device01_key.pem
-          - /usr/bin/credentials/lwm2m.pem
-    edge-identity-file:
-        interface: system-files
-        read:
-          - /var/snap/pelion-edge/current/userdata/edge_gw_identity/identity.json
-    support:
-        interface: docker-support
-    privileged:
-        interface: docker-support
-        privileged-containers: true
-    docker-cli:
-        interface: docker
-    dbus-wpa:
-        bus: system
-        interface: dbus
-        name: fi.w1.wpa_supplicant1
-    network:
+  home:
+    read: all
+  removable-media:
+  snapd:
+    interface: snapd-control
+    refresh-schedule: managed
+  system-files-logs:
+    interface: system-files
+    read:
+      - /run/systemd/journal
+      - /run/systemd/private
+      - /var/lib/snapd/apparmor/profiles
+    write:
+      - /run/systemd/journal
+      - /run/systemd/private
+      - /var/lib/snapd/apparmor/profiles
+      - /var/log
+      - /run/log/journal
+  usr-libexec-kubernetes:
+    interface: system-files
+    read:
+      - /usr/libexec/kubernetes
+      - /usr/libexec/kubernetes/volume
+      - /usr/libexec/kubernetes/volume/exec
+    write:
+      - /usr/libexec/kubernetes
+      - /usr/libexec/kubernetes/volume
+      - /usr/libexec/kubernetes/volume/exec
+  run-docker:
+    interface: system-files
+    read:
+      - /run/docker.pid
+      - /run/containerd/containerd.sock
+    write:
+      - /run/docker.pid
+      - /run/containerd/containerd.sock
+  etc-apparmor-abi:
+    interface: system-files
+    read:
+      - /etc/apparmor.d/abi/2.13
+  edge-tool-files:
+    interface: personal-files
+    read:
+      - $HOME/.mbed_cloud_config.json
+  testnet-credential-files:
+    interface: system-files
+    read:
+      - /usr/bin/credentials/bootstrap.pem
+      - /usr/bin/credentials/device01_cert.pem
+      - /usr/bin/credentials/device01_key.pem
+      - /usr/bin/credentials/lwm2m.pem
+  edge-identity-file:
+    interface: system-files
+    read:
+      - /var/snap/pelion-edge/current/userdata/edge_gw_identity/identity.json
+  support:
+    interface: docker-support
+  privileged:
+    interface: docker-support
+    privileged-containers: true
+  docker-cli:
+    interface: docker
+  dbus-wpa:
+    bus: system
+    interface: dbus
+    name: fi.w1.wpa_supplicant1
+  network:
 slots:
-    docker-daemon:
-        interface: docker
-    docker-executables:
-        content: docker-executables
-        interface: content
-        read:
-          - .
+  docker-daemon:
+    interface: docker
+  docker-executables:
+    content: docker-executables
+    interface: content
+    read:
+      - .
 layout:
-    /var/lib/dockershim:
-        bind: $SNAP_DATA/var/lib/dockershim
-    /etc/docker:
-        bind: $SNAP_DATA/etc/docker
-    /var/lib/kubelet:
-        bind: $SNAP_COMMON/var/lib/kubelet
-    /var/log/pods:
-        bind: $SNAP_COMMON/var/log/pods
-    /var/log/containers:
-        bind: $SNAP_COMMON/var/log/containers
-
+  /var/lib/dockershim:
+    bind: $SNAP_DATA/var/lib/dockershim
+  /etc/docker:
+    bind: $SNAP_DATA/etc/docker
+  /var/lib/kubelet:
+    bind: $SNAP_COMMON/var/lib/kubelet
+  /var/log/pods:
+    bind: $SNAP_COMMON/var/log/pods
+  /var/log/containers:
+    bind: $SNAP_COMMON/var/log/containers
 # List of applications (commands, binaries, daemons) in the snap.
 apps:
-    edge-tool:
-      command: bin/edge-tool
-      plugs:
-        - home
-        - edge-tool-files
-
-    edge-core:
-      restart-delay: 5s
-      restart-condition: always
-      command: launch-edge-core.sh
-      daemon: simple
-      environment:
-        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
-      plugs:
-        - docker
-        - hardware-observe
-        - kubernetes-support
-        - log-observe
-        - mount-observe
-        - network-bind
-        - network-control
-        - network-observe
-        - process-control
-        - shutdown
-        - snapd-control
-        - system-files-logs
-
-    help:
-      command: bin/print-help
-
-    fluent-bit:
-      restart-delay: 5s
-      restart-condition: always
-      command: launch-fluent-bit.sh
-      daemon: simple
-      plugs:
-        - network
-        - network-bind
-        - system-files-logs
-        - log-observe
-
-    maestro:
-      command: launch-maestro.sh
-      environment:
-        LD_LIBRARY_PATH: $SNAP/wigwag/system/lib
-      restart-delay: 5s
-      restart-condition: always
-      daemon: simple
-      plugs:
-        - account-control
-        - bluetooth-control
-        - dbus-wpa
-        - firewall-control
-        - hardware-observe
-        - log-observe
-        - modem-manager
-        - mount-observe
-        - netlink-audit
-        - netlink-connector
-        - network-bind
-        - network-control
-        - network-manager
-        - network-observe
-        - x11
-        - system-files-logs
-
-    edge-proxy:
-      restart-delay: 5s
-      restart-condition: always
-      command: launch-edge-proxy.sh
-      daemon: simple
-      plugs:
-        - network-bind
-        - network-control
-        - home
-
-    pe-terminal:
-      restart-delay: 5s
-      restart-condition: always
-      after: [edge-proxy]
-      command: launch-pe-terminal.sh
-      daemon: simple
-      environment:
-        TERM: xterm-256color
-      plugs:
+  edge-tool:
+    command: bin/edge-tool
+    plugs:
+      - home
+      - edge-tool-files
+  edge-core:
+    restart-delay: 5s
+    restart-condition: always
+    command: launch-edge-core.sh
+    daemon: simple
+    environment:
+      DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
+    plugs:
+      - docker
+      - hardware-observe
+      - kubernetes-support
+      - log-observe
+      - mount-observe
+      - network-bind
+      - network-control
+      - network-observe
+      - process-control
+      - shutdown
+      - snapd-control
+      - system-files-logs
+  help:
+    command: bin/print-help
+  fluent-bit:
+    restart-delay: 5s
+    restart-condition: always
+    command: launch-fluent-bit.sh
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+      - system-files-logs
+      - log-observe
+  maestro:
+    command: launch-maestro.sh
+    environment:
+      LD_LIBRARY_PATH: $SNAP/wigwag/system/lib
+    restart-delay: 5s
+    restart-condition: always
+    daemon: simple
+    plugs:
+      - account-control
+      - bluetooth-control
+      - dbus-wpa
+      - firewall-control
+      - hardware-observe
+      - log-observe
+      - modem-manager
+      - mount-observe
+      - netlink-audit
+      - netlink-connector
+      - network-bind
+      - network-control
+      - network-manager
+      - network-observe
+      - x11
+      - system-files-logs
+  edge-proxy:
+    restart-delay: 5s
+    restart-condition: always
+    command: launch-edge-proxy.sh
+    daemon: simple
+    plugs:
+      - network-bind
+      - network-control
+      - home
+  pe-terminal:
+    restart-delay: 5s
+    restart-condition: always
+    after: [edge-proxy]
+    command: launch-pe-terminal.sh
+    daemon: simple
+    environment:
+      TERM: xterm-256color
+    plugs:
       - network
       - ssh-keys
       - ssh-public-keys
@@ -195,249 +188,236 @@ apps:
       - network-manager
       - modem-manager
       - log-observe
-
-    identity:
-      command: launch-pelion-identity.sh $SNAP $SNAP_DATA
-      daemon: simple
-      plugs:
-        - network
-        - network-control
-
-    platform-version:
-      command: bin/platform-version.sh
-      plugs:
-        - snapd-control
-
-    kubelet:
-      restart-delay: 5s
-      after: [dockerd, bouncer]
-      restart-condition: always
-      command: launch-kubelet.sh
-      daemon: simple
-      environment:
-        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
-      plugs:
-        - bluetooth-control
-        - docker
-        - docker-cli
-        - firewall-control
-        - hardware-observe
-        - kubernetes-support
-        - log-observe
-        - mount-observe
-        - netlink-audit
-        - netlink-connector
-        - network-bind
-        - network-control
-        - network-observe
-        - process-control
-        - support
-        - system-files-logs
-        - system-observe
-        - system-trace
-        - run-docker
-        - usr-libexec-kubernetes
-        - etc-apparmor-abi
-
-    docker:
-      command: bin/docker
-      environment:
-        GIT_TEMPLATE_DIR: $SNAP/share/git-core/templates
-        GIT_CONFIG_NOSYSTEM: "true"
-        GIT_EXEC_PATH: $SNAP/libexec/git-core
-        GIT_TEXTDOMAINDIR: $SNAP/usr/share/locale
-        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
-      completer: bin/docker-completion.sh
-      plugs:
-        - docker-cli
-        - network
-        - home
-        - process-control
-        - network-control
-        - removable-media
-
-    dockerd:
-      command: bin/dockerd-wrapper
-      daemon: simple
-      environment:
-        DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
-      plugs:
-        - firewall-control
-        - fuse-support
-        - home
-        - kernel-module-observe
-        - log-observe
-        - microstack-support
-        - mount-observe
-        - network-bind
-        - network-control
-        - privileged
-        - process-control
-        - steam-support
-        - support
-      slots:
-        - docker-daemon
-
-    curl:
-      command: bin/curl
-      plugs:
-        - network
-
-    docker-help:
-      command: bin/help
-
-    version:
-      command: bin/print-versions
-
-    edge-info:
-      command: bin/edge-info
-      plugs:
-        - edge-identity-file
-        - mount-observe
-        - network-bind
-        - login-session-observe
-        - steam-support
-
-    edge-testnet:
-      command: bin/edge-testnet
-      plugs:
-        - network-bind
-        - testnet-credential-files
-        - steam-support
-
-    cosign:
-      command: bin/cosign
-
-    bouncer:
-      command: launch-bouncer.sh
-      daemon: simple
-      restart-delay: 5s
-      restart-condition: always
-      plugs:
-        - network-bind
+  identity:
+    command: launch-pelion-identity.sh $SNAP $SNAP_DATA
+    daemon: simple
+    plugs:
+      - network
+      - network-control
+  platform-version:
+    command: bin/platform-version.sh
+    plugs:
+      - snapd-control
+  kubelet:
+    restart-delay: 5s
+    after: [dockerd, bouncer]
+    restart-condition: always
+    command: launch-kubelet.sh
+    daemon: simple
+    environment:
+      DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
+    plugs:
+      - bluetooth-control
+      - docker
+      - docker-cli
+      - firewall-control
+      - hardware-observe
+      - kubernetes-support
+      - log-observe
+      - mount-observe
+      - netlink-audit
+      - netlink-connector
+      - network-bind
+      - network-control
+      - network-observe
+      - process-control
+      - support
+      - system-files-logs
+      - system-observe
+      - system-trace
+      - run-docker
+      - usr-libexec-kubernetes
+      - etc-apparmor-abi
+  docker:
+    command: bin/docker
+    environment:
+      GIT_TEMPLATE_DIR: $SNAP/share/git-core/templates
+      GIT_CONFIG_NOSYSTEM: "true"
+      GIT_EXEC_PATH: $SNAP/libexec/git-core
+      GIT_TEXTDOMAINDIR: $SNAP/usr/share/locale
+      DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
+    completer: bin/docker-completion.sh
+    plugs:
+      - docker-cli
+      - network
+      - home
+      - process-control
+      - network-control
+      - removable-media
+  dockerd:
+    command: bin/dockerd-wrapper
+    daemon: simple
+    environment:
+      DOCKER_HOST: unix:///run/snap.$SNAP_INSTANCE_NAME/var/run/docker.sock
+    plugs:
+      - firewall-control
+      - fuse-support
+      - home
+      - kernel-module-observe
+      - log-observe
+      - microstack-support
+      - mount-observe
+      - network-bind
+      - network-control
+      - privileged
+      - process-control
+      - steam-support
+      - support
+    slots:
+      - docker-daemon
+  curl:
+    command: bin/curl
+    plugs:
+      - network
+  docker-help:
+    command: bin/help
+  version:
+    command: bin/print-versions
+  edge-info:
+    command: bin/edge-info
+    plugs:
+      - edge-identity-file
+      - mount-observe
+      - network-bind
+      - login-session-observe
+      - steam-support
+  edge-testnet:
+    command: bin/edge-testnet
+    plugs:
+      - network-bind
+      - testnet-credential-files
+      - steam-support
+  cosign:
+    command: bin/cosign
+  bouncer:
+    command: launch-bouncer.sh
+    daemon: simple
+    restart-delay: 5s
+    restart-condition: always
+    plugs:
+      - network-bind
 parts:
-    help:
-      plugin: dump
-      source: files/help/
-      override-build: |
-        snapcraftctl build
-        chmod a+x bin/print-help
-    version:
-      plugin: dump
-      source: files/version/
-      override-build: |
-        snapcraftctl build
-        chmod a+x print-versions.sh
-      organize:
-        print-versions.sh: bin/print-versions
-    platform-version:
-      plugin: dump
-      source: files/platform-version/
-      organize:
-        platform-version.sh: bin/platform-version.sh
-    identity:
-      plugin: dump
-      source: files/identity/
-    nmcli:
-      plugin: nil
-      stage-packages:
-        - network-manager
-        - libslang2
-        - libatm1
-      organize:
-        usr/bin/nmcli: bin/nmcli
-    mmcli:
-      plugin: nil
-      stage-packages:
-        - modemmanager
-      organize:
-        usr/bin/mmcli: bin/mmcli
-    snap:
-      plugin: nil
-      stage-packages:
-        - snapd
-      organize:
-        usr/bin/snap: bin/snap
-
-    edge-core-src:
-      plugin: cmake
-      source: https://github.com/PelionIoT/mbed-edge.git
-      source-tag: 0.21.0
-      build-environment:
-        - COAP_PORT_OVERRIDE_443: "false"
-      stage-packages: [coreutils]
-      override-pull: |
-        snapcraftctl pull
-        cp "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/src/mbed_cloud_client_user_config.h" config/mbed_cloud_client_user_config.h
-        cp "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/src/sotp_fs_linux.h" config/sotp_fs_linux.h
-        cp "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/src/osreboot.c" edge-core/osreboot.c
-        cp "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/cmake/target.cmake" config/target.cmake
-        cp "${SNAPCRAFT_PART_SRC}/cmake/toolchains/mcc-linux-x86.cmake" config/toolchain.cmake
-        # patch the mbed-cloud-client library
-        sed -i 's!/dev/random!/dev/urandom!' lib/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/Board_Specific/TARGET_x86_x64/pal_plat_x86_x64.c
-        sed -i 's!\(MAX_RECONNECT_TIMEOUT\).*!\1 60!' lib/mbed-cloud-client/mbed-client/mbed-client/m2mconstants.h
-        git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-Add-PAL-Proxy-module-using-HTTP.patch
-        git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0002-Increasing-Path-Size.patch
-        git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0003-Call-a-restart-script-during-fota.patch
-        git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0004-use-customized-edge-core-update-scripts.patch
-        git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0005-Read-platform-version-files-into-LWM2M-resources.patch
-        # patch edge-core
-        git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0010-Add-network-proxy-support.patch"
-        git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0011-Call-a-script-on-factory-reset.patch"
-        git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0013-add-stubs-for-gateway-statistics-resources.patch"
-        git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0014-add-cpu-usage-3-0-3320.patch"
-        git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0015-add-cpu-temp-3-0-3303.patch"
-        git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0016-add-RAM-total-3-0-3322-and-RAM-free-3-0-3321.patch"
-        git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0017-add-disk-free-3-0-3323-and-disk-total-3-0-3324.patch"
-        git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0018-add-snap-version-3-0-4001.patch"
-        if [ "${COAP_PORT_OVERRIDE_443}" = "true" ]; then
-            echo "PATCHING PORT 443 OVERRIDE"
-            [ -f config/mbed_cloud_dev_credentials.c ] && sed -i 's,\(coaps://[^:]*:\)5684,\1443,' config/mbed_cloud_dev_credentials.c
-            git apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0019-force-port-443.patch
-        fi
-      override-build: |
-        tar -C "${SNAPCRAFT_PART_SRC}" -czf "${SNAPCRAFT_PART_BUILD}/edge-core-src.tgz" .
-        cp edge-core-src.tgz "${SNAPCRAFT_PART_INSTALL}"
-        install -d "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed"
-        install "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/config/edge-core.conf" "${SNAPCRAFT_PART_INSTALL}/"
-        install "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/scripts/edge-core-bootloader.sh" "${SNAPCRAFT_PART_INSTALL}/"
-        install "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/scripts/edge-core-factory-reset" "${SNAPCRAFT_PART_INSTALL}/"
-        install "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/scripts/launch-edge-core.sh" "${SNAPCRAFT_PART_INSTALL}/"
-        # install the generic update scripts
-        install ${SNAPCRAFT_PART_SRC}/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/scripts/generic/*.sh ${SNAPCRAFT_PART_INSTALL}/wigwag/mbed/
-        # Override the generic update scripts with our own
-        echo "Override the generic update scripts with our own"
-        install "${SNAPCRAFT_PROJECT_DIR}"/files/edge-core/scripts/arm_update_*.sh "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed"
-      prime: ['*', -edge-core-src.tgz]
-    edge-core:
-      # this variant of edge-core is compiled with factory provisioning mode
-      plugin: cmake
-      after:
+  help:
+    plugin: dump
+    source: files/help/
+    override-build: |
+      snapcraftctl build
+      chmod a+x bin/print-help
+  version:
+    plugin: dump
+    source: files/version/
+    override-build: |
+      snapcraftctl build
+      chmod a+x print-versions.sh
+    organize:
+      print-versions.sh: bin/print-versions
+  platform-version:
+    plugin: dump
+    source: files/platform-version/
+    organize:
+      platform-version.sh: bin/platform-version.sh
+  identity:
+    plugin: dump
+    source: files/identity/
+  nmcli:
+    plugin: nil
+    stage-packages:
+      - network-manager
+      - libslang2
+      - libatm1
+    organize:
+      usr/bin/nmcli: bin/nmcli
+  mmcli:
+    plugin: nil
+    stage-packages:
+      - modemmanager
+    organize:
+      usr/bin/mmcli: bin/mmcli
+  snap:
+    plugin: nil
+    stage-packages:
+      - snapd
+    organize:
+      usr/bin/snap: bin/snap
+  edge-core-src:
+    plugin: cmake
+    source: https://github.com/PelionIoT/mbed-edge.git
+    source-tag: 0.21.0
+    build-environment:
+      - COAP_PORT_OVERRIDE_443: "false"
+    stage-packages: [coreutils]
+    override-pull: |
+      snapcraftctl pull
+      cp "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/src/mbed_cloud_client_user_config.h" config/mbed_cloud_client_user_config.h
+      cp "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/src/sotp_fs_linux.h" config/sotp_fs_linux.h
+      cp "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/src/osreboot.c" edge-core/osreboot.c
+      cp "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/cmake/target.cmake" config/target.cmake
+      cp "${SNAPCRAFT_PART_SRC}/cmake/toolchains/mcc-linux-x86.cmake" config/toolchain.cmake
+      # patch the mbed-cloud-client library
+      sed -i 's!/dev/random!/dev/urandom!' lib/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/Board_Specific/TARGET_x86_x64/pal_plat_x86_x64.c
+      sed -i 's!\(MAX_RECONNECT_TIMEOUT\).*!\1 60!' lib/mbed-cloud-client/mbed-client/mbed-client/m2mconstants.h
+      git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0001-Add-PAL-Proxy-module-using-HTTP.patch
+      git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0002-Increasing-Path-Size.patch
+      git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0003-Call-a-restart-script-during-fota.patch
+      git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0004-use-customized-edge-core-update-scripts.patch
+      git -C lib/mbed-cloud-client/ apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0005-Read-platform-version-files-into-LWM2M-resources.patch
+      # patch edge-core
+      git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0010-Add-network-proxy-support.patch"
+      git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0011-Call-a-script-on-factory-reset.patch"
+      git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0013-add-stubs-for-gateway-statistics-resources.patch"
+      git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0014-add-cpu-usage-3-0-3320.patch"
+      git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0015-add-cpu-temp-3-0-3303.patch"
+      git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0016-add-RAM-total-3-0-3322-and-RAM-free-3-0-3321.patch"
+      git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0017-add-disk-free-3-0-3323-and-disk-total-3-0-3324.patch"
+      git apply "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0018-add-snap-version-3-0-4001.patch"
+      if [ "${COAP_PORT_OVERRIDE_443}" = "true" ]; then
+          echo "PATCHING PORT 443 OVERRIDE"
+          [ -f config/mbed_cloud_dev_credentials.c ] && sed -i 's,\(coaps://[^:]*:\)5684,\1443,' config/mbed_cloud_dev_credentials.c
+          git apply ${SNAPCRAFT_PROJECT_DIR}/files/edge-core/patches/0019-force-port-443.patch
+      fi
+    override-build: |
+      tar -C "${SNAPCRAFT_PART_SRC}" -czf "${SNAPCRAFT_PART_BUILD}/edge-core-src.tgz" .
+      cp edge-core-src.tgz "${SNAPCRAFT_PART_INSTALL}"
+      install -d "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed"
+      install "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/config/edge-core.conf" "${SNAPCRAFT_PART_INSTALL}/"
+      install "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/scripts/edge-core-bootloader.sh" "${SNAPCRAFT_PART_INSTALL}/"
+      install "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/scripts/edge-core-factory-reset" "${SNAPCRAFT_PART_INSTALL}/"
+      install "${SNAPCRAFT_PROJECT_DIR}/files/edge-core/scripts/launch-edge-core.sh" "${SNAPCRAFT_PART_INSTALL}/"
+      # install the generic update scripts
+      install ${SNAPCRAFT_PART_SRC}/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/scripts/generic/*.sh ${SNAPCRAFT_PART_INSTALL}/wigwag/mbed/
+      # Override the generic update scripts with our own
+      echo "Override the generic update scripts with our own"
+      install "${SNAPCRAFT_PROJECT_DIR}"/files/edge-core/scripts/arm_update_*.sh "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed"
+    prime: ['*', -edge-core-src.tgz]
+  edge-core:
+    # this variant of edge-core is compiled with factory provisioning mode
+    plugin: cmake
+    after:
       - edge-core-src
-      source: "${SNAPCRAFT_STAGE}/edge-core-src.tgz"
-      cmake-parameters:
-        - -DCMAKE_BUILD_TYPE=Release
-        - -DTRACE_LEVEL=WARN
-        - -DFIRMWARE_UPDATE=ON
-        - -DDEVELOPER_MODE=OFF
-        - -DFACTORY_MODE=ON
-        - -DFOTA_ENABLE=OFF
-        - -DMBED_CLOUD_CLIENT_CURL_DYNAMIC_LINK=OFF
-        - -DBYOC_MODE=OFF
-        - -DTARGET_CONFIG_ROOT=${SNAPCRAFT_PART_SRC}/config
-        - -DMBED_CLOUD_DEV_UPDATE_ID=ON
-        - -DNETWORK_PROXY_SUPPORT=ON
-        - -DPARSEC_TPM_SE_SUPPORT=OFF
-      override-build: |
-        snapcraftctl build
-        install -d "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed"
-        install bin/edge-core "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed/edge-core"
-      stage:
-        - wigwag/mbed/edge-core
-    edge-core-dev:
-      # this variant of edge-core is compiled with developer provisioning mode
-      plugin: cmake
-      build-packages:
+    source: "${SNAPCRAFT_STAGE}/edge-core-src.tgz"
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DTRACE_LEVEL=WARN
+      - -DFIRMWARE_UPDATE=ON
+      - -DDEVELOPER_MODE=OFF
+      - -DFACTORY_MODE=ON
+      - -DFOTA_ENABLE=OFF
+      - -DMBED_CLOUD_CLIENT_CURL_DYNAMIC_LINK=OFF
+      - -DBYOC_MODE=OFF
+      - -DTARGET_CONFIG_ROOT=${SNAPCRAFT_PART_SRC}/config
+      - -DMBED_CLOUD_DEV_UPDATE_ID=ON
+      - -DNETWORK_PROXY_SUPPORT=ON
+      - -DPARSEC_TPM_SE_SUPPORT=OFF
+    override-build: |
+      snapcraftctl build
+      install -d "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed"
+      install bin/edge-core "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed/edge-core"
+    stage:
+      - wigwag/mbed/edge-core
+  edge-core-dev:
+    # this variant of edge-core is compiled with developer provisioning mode
+    plugin: cmake
+    build-packages:
       - build-essential
       - clang
       - gcc
@@ -445,422 +425,407 @@ parts:
       - libclang-dev
       - libcurl4-openssl-dev
       - libgpiod-dev
-      after:
+    after:
       - edge-core-src
-      source: "${SNAPCRAFT_STAGE}/edge-core-src.tgz"
-      cmake-parameters:
-        - -DCMAKE_BUILD_TYPE=Release
-        - -DTRACE_LEVEL=WARN
-        - -DFIRMWARE_UPDATE=ON
-        - -DDEVELOPER_MODE=ON
-        - -DFACTORY_MODE=OFF
-        - -DFOTA_ENABLE=OFF
-        - -DMBED_CLOUD_CLIENT_CURL_DYNAMIC_LINK=OFF
-        - -DBYOC_MODE=OFF
-        - -DTARGET_CONFIG_ROOT=${SNAPCRAFT_PART_SRC}/config
-        - -DMBED_CLOUD_DEV_UPDATE_ID=ON
-        - -DNETWORK_PROXY_SUPPORT=ON
-        - -DPARSEC_TPM_SE_SUPPORT=OFF
-      override-pull: |
-        snapcraftctl pull
-        # mbed_cloud_dev_credentials.c is required if DEVELOPER_MODE=ON
-        # update_default_resources.c is required if DEVELOPER_MODE=ON && FIRMWARE_UPDATE=ON
-        # Piping to true allows the cp to not fail when the file is not present
-        cp "${SNAPCRAFT_PROJECT_DIR}/mbed_cloud_dev_credentials.c" config/mbed_cloud_dev_credentials.c || true
-        cp "${SNAPCRAFT_PROJECT_DIR}/update_default_resources.c" config/update_default_resources.c || true
-      override-build: |
-        install -d "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed"
-        if [ "${SNAPCRAFT_PROJECT_GRADE}" = "devel" ]; then
-            # allow devmode to succeed if the credentials don't exist.  if this is the case,
-            # then we won't install the devmode version of edge-core into the snap.
-            if [ -f "${SNAPCRAFT_PART_SRC}/config/mbed_cloud_dev_credentials.c" ]; then
-                snapcraftctl build
-                install bin/edge-core "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed/edge-core-dev"
-            fi
-        fi
-      stage:
-        - wigwag/mbed/*
-    edge-core-byoc:
-      # this variant of edge-core is compiled with byoc provisioning mode
-      plugin: cmake
-      build-packages:
-      - build-essential
-      - clang
-      - gcc
-      - libc6-dev
-      - libclang-dev
-      - libcurl4-openssl-dev
-      - libgpiod-dev
-      after:
-      - edge-core-src
-      source: "${SNAPCRAFT_STAGE}/edge-core-src.tgz"
-      cmake-parameters:
-        - -DCMAKE_BUILD_TYPE=Release
-        - -DTRACE_LEVEL=WARN
-        - -DDEVELOPER_MODE=OFF
-        - -DFACTORY_MODE=OFF
-        - -DBYOC_MODE=ON
-        - -DFIRMWARE_UPDATE=ON
-        - -DFOTA_ENABLE=OFF
-        - -DMBED_CLOUD_CLIENT_CURL_DYNAMIC_LINK=OFF
-        - -DTARGET_CONFIG_ROOT=${SNAPCRAFT_PART_SRC}/config
-        - -DMBED_CLOUD_DEV_UPDATE_ID=ON
-        - -DNETWORK_PROXY_SUPPORT=ON
-        - -DPARSEC_TPM_SE_SUPPORT=OFF
-      override-build: |
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/mbed
-        if [ "${SNAPCRAFT_PROJECT_GRADE}" = "devel" ]; then
-            snapcraftctl build
-            install bin/edge-core ${SNAPCRAFT_PART_INSTALL}/wigwag/mbed/edge-core-byoc
-        fi
-      stage:
-        - wigwag/mbed/*
-
-    edge-core-tool:
-      after:
-        - edge-core-src
-      plugin: python
-      source: "${SNAPCRAFT_STAGE}/edge-core-src.tgz"
-      source-subdir: edge-tool
-      requirements: ["${SNAPCRAFT_PART_SRC}/edge-tool/requirements.txt"]
-      override-build: |
-        if [ "${SNAPCRAFT_PROJECT_GRADE}" = "devel" ]; then
-            snapcraftctl build
-        fi
-        install -d ${SNAPCRAFT_PART_INSTALL}/bin
-        install ${SNAPCRAFT_PROJECT_DIR}/files/edge-core-tool/edge-core-tool.sh ${SNAPCRAFT_PART_INSTALL}/bin/edge-tool
-      organize:
-        bin/edge_tool.py: wigwag/mbed/edge-tool/edge_tool.py
-        bin/cbor_converter.py: wigwag/mbed/edge-tool/cbor_converter.py
-    edge-proxy:
-      plugin: go
-      source: https://github.com/PelionIoT/edge-proxy.git
-      source-tag: v1.3.0
-      build-environment:
-        - GOFLAGS: "$GOFLAGS -modcacherw"
-      override-build: |
-        export ALT_GO=go1.18
-        export ORI_GO=go1.15
-        export GOROOT=/usr/local/$ALT_GO
-        export PATH="$GOROOT/bin:$PATH"
-        echo Hacking/changing the go version to $ALT_GO
-        sudo rm /usr/local/bin/go /usr/local/bin/gofmt
-        sudo ln -sf "/usr/local/$ALT_GO/bin/go" /usr/local/bin/go
-        sudo ln -sf "/usr/local/$ALT_GO/bin/gofmt" /usr/local/bin/gofmt
-
-        snapcraftctl build
-
-        echo Reverting the go version to $ORI_GO
-        sudo rm /usr/local/bin/go /usr/local/bin/gofmt
-        sudo ln -sf "/usr/local/$ORI_GO/bin/go" /usr/local/bin/go
-        sudo ln -sf "/usr/local/$ORI_GO/bin/gofmt" /usr/local/bin/gofmt
-
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
-        install ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/config/edge-proxy.conf.json ${SNAPCRAFT_PART_INSTALL}/
-        install ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/scripts/launch-edge-proxy.sh ${SNAPCRAFT_PART_INSTALL}/
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge
-        git describe --tags --always > ${SNAPCRAFT_PART_INSTALL}/edge/edge-proxy.VERSION
-      organize:
-        bin/edge-proxy: wigwag/system/bin/edge-proxy
-
-    pe-terminal:
-      plugin: go
-      source: https://github.com/PelionIoT/pe-terminal.git
-      source-tag: v1.1.0
-      build-environment:
-        - GOFLAGS: "$GOFLAGS -modcacherw"
-      override-build: |
-        export ALT_GO=go1.18
-        export ORI_GO=go1.15
-        export GOROOT=/usr/local/$ALT_GO
-        export PATH="$GOROOT/bin:$PATH"
-
-        echo Hacking/changing the go version to $ALT_GO
-        sudo rm /usr/local/bin/go /usr/local/bin/gofmt
-        sudo ln -sf "/usr/local/$ALT_GO/bin/go" /usr/local/bin/go
-        sudo ln -sf "/usr/local/$ALT_GO/bin/gofmt" /usr/local/bin/gofmt
-
-        snapcraftctl build
-
-        echo Reverting the go version to $ORI_GO
-        sudo rm /usr/local/bin/go /usr/local/bin/gofmt
-        sudo ln -sf "/usr/local/$ORI_GO/bin/go" /usr/local/bin/go
-        sudo ln -sf "/usr/local/$ORI_GO/bin/gofmt" /usr/local/bin/gofmt
-
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge
-        git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/pe-terminal.VERSION"
-
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
-        install ${SNAPCRAFT_PROJECT_DIR}/files/pe-terminal/config/pe-terminal.conf.json ${SNAPCRAFT_PART_INSTALL}/
-        install ${SNAPCRAFT_PROJECT_DIR}/files/pe-terminal/launch-pe-terminal.sh ${SNAPCRAFT_PART_INSTALL}/
-      organize:
-        bin/pe-terminal: wigwag/system/bin/pe-terminal
-
-    pe-utils:
-      plugin: nil
-      source: https://github.com/PelionIoT/pe-utils.git
-      source-tag: 2.3.0
-      override-build: |
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge/etc
-        install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/versions.json ${SNAPCRAFT_PART_INSTALL}/edge/
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
-        cp -r identity-tools ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils/
-        chmod -R 0755 ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
-        install -d ${SNAPCRAFT_PART_INSTALL}/bin/credentials
-        cp -r fw-tools/credentials/* ${SNAPCRAFT_PART_INSTALL}/bin/credentials
-        git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/pe-utils.VERSION"
-      stage-packages:
-        - gawk
-        - bc
-        - procps
-        - net-tools
-
-    edge-info:
-      plugin: dump
-      source: https://github.com/PelionIoT/pe-utils.git
-      source-tag: 2.3.0
-      override-build: |
-        install -d "${SNAPCRAFT_PART_INSTALL}/edge"
-        git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-info.VERSION"
-        snapcraftctl build
-      organize:
-        'edge-info/edge-info': bin/edge-info
-      stage-packages:
-        - gawk
-        - bc
-        - procps
-        - net-tools
-
-    edge-testnet:
-      plugin: dump
-      source: https://github.com/PelionIoT/pe-utils.git
-      source-tag: 2.3.0
-      override-build: |
-        install -d "${SNAPCRAFT_PART_INSTALL}/edge"
-        git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-testnet.VERSION"
-        snapcraftctl build
-      organize:
-        'fw-tools/edge-testnet': bin/edge-testnet
-        'fw-tools/credentials/bootstrap.pem': bin/credentials/bootstrap.pem
-        'fw-tools/credentials/device01_cert.pem': bin/credentials/device01_cert.pem
-        'fw-tools/credentials/device01_key.pem': bin/credentials/device01_key.pem
-        'fw-tools/credentials/lwm2m.pem': bin/credentials/lwm2m.pem
-      stage-packages:
-        - net-tools
-        - netcat-openbsd
-
-    yq:
-      plugin: go
-      build-environment:
-        - GOFLAGS: "$GOFLAGS -modcacherw"
-      source: https://github.com/mikefarah/yq.git
-      source-tag: 3.4.1
-
-    maestro:
-      plugin: make
-      source: https://github.com/PelionIoT/maestro.git
-      source-commit: v3.0.0
-      build-packages:
-        - libuv1-dev
-      build-environment:
-        - GOFLAGS: "$GOFLAGS -modcacherw"
-      override-build: |
-        # setup the go build environment
-        . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
-        gopartbootstrap github.com/PelionIoT/maestro
-        # Specify GOBIN so that maestro/build.sh doesn't do unexpected things
-        export GOBIN=${GOPATH}/bin
-
-        go build -o ${GOPATH}/bin/maestro maestro/main.go
-
-        # Install maestro components into the SNAPCRAFT_PART_INSTALL folder so that it is
-        # copied into the prime directory during the prime step
-        install ${SNAPCRAFT_PROJECT_DIR}/files/maestro/launch-maestro.sh ${SNAPCRAFT_PART_INSTALL}/
-
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates
-        install ${SNAPCRAFT_PROJECT_DIR}/files/maestro/config/maestro-config-dell5000.yaml ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates/
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
-        install ${GOPATH}/bin/maestro ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/maestro
-
-        # fixup the SNAP and SNAP_DATA variables in the config files based on the snap name
-        sed -i "s!/snap/pelion-edge!/snap/${SNAPCRAFT_PROJECT_NAME}!" ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates/*.yaml
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge
-        git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/maestro.VERSION"
-      stage-packages:
-        - libuv1
-
-    fluent-bit:
-      plugin: cmake
-      source: https://github.com/fluent/fluent-bit.git
-      source-tag: v1.7.9
-      build-packages:
-        - libsystemd-dev
-        - flex
-        - bison
-      cmake-parameters:
-        - -DCMAKE_INSTALL_PREFIX=""
-        - -DFLB_JEMALLOC=On
-        - -DFLB_SHARED_LIB=Off
-        - -DFLB_EXAMPLES=Off
-        - -DFLB_IN_SYSTEMD=On
-      override-build: |
-        snapcraftctl build
-        install ${SNAPCRAFT_PROJECT_DIR}/files/fluent-bit/config/fluent-bit.conf ${SNAPCRAFT_PART_INSTALL}/
-        install ${SNAPCRAFT_PROJECT_DIR}/files/fluent-bit/scripts/launch-fluent-bit.sh ${SNAPCRAFT_PART_INSTALL}/
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge
-        git describe --tags --always > ${SNAPCRAFT_PART_INSTALL}/edge/fluent-bit.VERSION
-      organize:
-        bin/fluent-bit: wigwag/system/bin/fluent-bit
-
-    cni:
-      plugin: go
-      source: https://github.com/containernetworking/plugins.git
-      source-commit: 1f33fb729ae2b8900785f896df2dc1f6fe5e8239
-      override-build: |
-        export GOPATH=${SNAPCRAFT_PART_SRC}/../go
-
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/opt/cni/bin
-        PLUGINS="plugins/meta/* plugins/main/* plugins/ipam/*"
-        for d in $PLUGINS; do
-          echo "$d"
-          if [ -d "$d" ]; then
-            plugin="$(basename "$d")"
-            if [ $plugin != "windows" ]; then
-              echo "  cni/$plugin"
-              go install github.com/containernetworking/plugins/$d
-              # Build happens in parts/cni/build - use relative path to enable cross-compilation
-              install ../install/bin/$plugin ${SNAPCRAFT_PART_INSTALL}/wigwag/system/opt/cni/bin/$plugin
-            fi
+    source: "${SNAPCRAFT_STAGE}/edge-core-src.tgz"
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DTRACE_LEVEL=WARN
+      - -DFIRMWARE_UPDATE=ON
+      - -DDEVELOPER_MODE=ON
+      - -DFACTORY_MODE=OFF
+      - -DFOTA_ENABLE=OFF
+      - -DMBED_CLOUD_CLIENT_CURL_DYNAMIC_LINK=OFF
+      - -DBYOC_MODE=OFF
+      - -DTARGET_CONFIG_ROOT=${SNAPCRAFT_PART_SRC}/config
+      - -DMBED_CLOUD_DEV_UPDATE_ID=ON
+      - -DNETWORK_PROXY_SUPPORT=ON
+      - -DPARSEC_TPM_SE_SUPPORT=OFF
+    override-pull: |
+      snapcraftctl pull
+      # mbed_cloud_dev_credentials.c is required if DEVELOPER_MODE=ON
+      # update_default_resources.c is required if DEVELOPER_MODE=ON && FIRMWARE_UPDATE=ON
+      # Piping to true allows the cp to not fail when the file is not present
+      cp "${SNAPCRAFT_PROJECT_DIR}/mbed_cloud_dev_credentials.c" config/mbed_cloud_dev_credentials.c || true
+      cp "${SNAPCRAFT_PROJECT_DIR}/update_default_resources.c" config/update_default_resources.c || true
+    override-build: |
+      install -d "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed"
+      if [ "${SNAPCRAFT_PROJECT_GRADE}" = "devel" ]; then
+          # allow devmode to succeed if the credentials don't exist.  if this is the case,
+          # then we won't install the devmode version of edge-core into the snap.
+          if [ -f "${SNAPCRAFT_PART_SRC}/config/mbed_cloud_dev_credentials.c" ]; then
+              snapcraftctl build
+              install bin/edge-core "${SNAPCRAFT_PART_INSTALL}/wigwag/mbed/edge-core-dev"
           fi
-        done
+      fi
+    stage:
+      - wigwag/mbed/*
+  edge-core-byoc:
+    # this variant of edge-core is compiled with byoc provisioning mode
+    plugin: cmake
+    build-packages:
+      - build-essential
+      - clang
+      - gcc
+      - libc6-dev
+      - libclang-dev
+      - libcurl4-openssl-dev
+      - libgpiod-dev
+    after:
+      - edge-core-src
+    source: "${SNAPCRAFT_STAGE}/edge-core-src.tgz"
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DTRACE_LEVEL=WARN
+      - -DDEVELOPER_MODE=OFF
+      - -DFACTORY_MODE=OFF
+      - -DBYOC_MODE=ON
+      - -DFIRMWARE_UPDATE=ON
+      - -DFOTA_ENABLE=OFF
+      - -DMBED_CLOUD_CLIENT_CURL_DYNAMIC_LINK=OFF
+      - -DTARGET_CONFIG_ROOT=${SNAPCRAFT_PART_SRC}/config
+      - -DMBED_CLOUD_DEV_UPDATE_ID=ON
+      - -DNETWORK_PROXY_SUPPORT=ON
+      - -DPARSEC_TPM_SE_SUPPORT=OFF
+    override-build: |
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/mbed
+      if [ "${SNAPCRAFT_PROJECT_GRADE}" = "devel" ]; then
+          snapcraftctl build
+          install bin/edge-core ${SNAPCRAFT_PART_INSTALL}/wigwag/mbed/edge-core-byoc
+      fi
+    stage:
+      - wigwag/mbed/*
+  edge-core-tool:
+    after:
+      - edge-core-src
+    plugin: python
+    source: "${SNAPCRAFT_STAGE}/edge-core-src.tgz"
+    source-subdir: edge-tool
+    requirements: ["${SNAPCRAFT_PART_SRC}/edge-tool/requirements.txt"]
+    override-build: |
+      if [ "${SNAPCRAFT_PROJECT_GRADE}" = "devel" ]; then
+          snapcraftctl build
+      fi
+      install -d ${SNAPCRAFT_PART_INSTALL}/bin
+      install ${SNAPCRAFT_PROJECT_DIR}/files/edge-core-tool/edge-core-tool.sh ${SNAPCRAFT_PART_INSTALL}/bin/edge-tool
+    organize:
+      bin/edge_tool.py: wigwag/mbed/edge-tool/edge_tool.py
+      bin/cbor_converter.py: wigwag/mbed/edge-tool/cbor_converter.py
+  edge-proxy:
+    plugin: go
+    source: https://github.com/PelionIoT/edge-proxy.git
+    source-tag: v1.3.0
+    build-environment:
+      - GOFLAGS: "$GOFLAGS -modcacherw"
+    override-build: |
+      export ALT_GO=go1.18
+      export ORI_GO=go1.15
+      export GOROOT=/usr/local/$ALT_GO
+      export PATH="$GOROOT/bin:$PATH"
+      echo Hacking/changing the go version to $ALT_GO
+      sudo rm /usr/local/bin/go /usr/local/bin/gofmt
+      sudo ln -sf "/usr/local/$ALT_GO/bin/go" /usr/local/bin/go
+      sudo ln -sf "/usr/local/$ALT_GO/bin/gofmt" /usr/local/bin/gofmt
 
-        install -m 0755 ${SNAPCRAFT_PROJECT_DIR}/files/cni/c2d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/opt/cni/bin/c2d
-        install -m 0755 ${SNAPCRAFT_PROJECT_DIR}/files/cni/c2d-inner ${SNAPCRAFT_PART_INSTALL}/wigwag/system/opt/cni/bin/c2d-inner
+      snapcraftctl build
 
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/etc/cni/net.d
-        install -m 0644 ${SNAPCRAFT_PROJECT_DIR}/files/cni/10-c2d.conf ${SNAPCRAFT_PART_INSTALL}/wigwag/system/etc/cni/net.d/10-c2d.conf
-        install -m 0644 ${SNAPCRAFT_PROJECT_DIR}/files/cni/99-loopback.conf ${SNAPCRAFT_PART_INSTALL}/wigwag/system/etc/cni/net.d/99-loopback.conf
+      echo Reverting the go version to $ORI_GO
+      sudo rm /usr/local/bin/go /usr/local/bin/gofmt
+      sudo ln -sf "/usr/local/$ORI_GO/bin/go" /usr/local/bin/go
+      sudo ln -sf "/usr/local/$ORI_GO/bin/gofmt" /usr/local/bin/gofmt
 
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge
-        git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/cni.VERSION"
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
+      install ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/config/edge-proxy.conf.json ${SNAPCRAFT_PART_INSTALL}/
+      install ${SNAPCRAFT_PROJECT_DIR}/files/edge-proxy/scripts/launch-edge-proxy.sh ${SNAPCRAFT_PART_INSTALL}/
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge
+      git describe --tags --always > ${SNAPCRAFT_PART_INSTALL}/edge/edge-proxy.VERSION
+    organize:
+      bin/edge-proxy: wigwag/system/bin/edge-proxy
+  pe-terminal:
+    plugin: go
+    source: https://github.com/PelionIoT/pe-terminal.git
+    source-tag: v1.1.0
+    build-environment:
+      - GOFLAGS: "$GOFLAGS -modcacherw"
+    override-build: |
+      export ALT_GO=go1.18
+      export ORI_GO=go1.15
+      export GOROOT=/usr/local/$ALT_GO
+      export PATH="$GOROOT/bin:$PATH"
 
-    kubelet:
-      plugin: make
-      source: https://github.com/PelionIoT/edge-kubelet.git
-      source-commit: 35225842cd6b20d98613d8c1b08b7a376bd3209d
-      build-packages:
-        - libseccomp-dev
-      override-build: |
-        # setup the go build environment
-        . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
-        gopartbootstrap k8s.io/kubernetes
+      echo Hacking/changing the go version to $ALT_GO
+      sudo rm /usr/local/bin/go /usr/local/bin/gofmt
+      sudo ln -sf "/usr/local/$ALT_GO/bin/go" /usr/local/bin/go
+      sudo ln -sf "/usr/local/$ALT_GO/bin/gofmt" /usr/local/bin/gofmt
 
-        cd hack/make-rules
-        KUBE_VERBOSE=0 ./build.sh cmd/kubelet
+      snapcraftctl build
 
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/var/lib/kubelet
-        install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
-        install -m 0644 ${SNAPCRAFT_PROJECT_DIR}/files/kubelet/config/kubeconfig ${SNAPCRAFT_PART_INSTALL}/wigwag/system/var/lib/kubelet/kubeconfig
-        install -m 0755 ${GOPATH}/src/k8s.io/kubernetes/_output/bin/kubelet ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/kubelet
-        install ${SNAPCRAFT_PROJECT_DIR}/files/kubelet/scripts/launch-kubelet.sh ${SNAPCRAFT_PART_INSTALL}/
-        install ${SNAPCRAFT_PROJECT_DIR}/files/kubelet/scripts/launch-edgenet.sh ${SNAPCRAFT_PART_INSTALL}/
+      echo Reverting the go version to $ORI_GO
+      sudo rm /usr/local/bin/go /usr/local/bin/gofmt
+      sudo ln -sf "/usr/local/$ORI_GO/bin/go" /usr/local/bin/go
+      sudo ln -sf "/usr/local/$ORI_GO/bin/gofmt" /usr/local/bin/gofmt
 
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge
-        git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/kubelet.VERSION"
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge
+      git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/pe-terminal.VERSION"
 
-      stage:
-        - -usr/share/*
-      stage-packages: [systemd, util-linux]
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
+      install ${SNAPCRAFT_PROJECT_DIR}/files/pe-terminal/config/pe-terminal.conf.json ${SNAPCRAFT_PART_INSTALL}/
+      install ${SNAPCRAFT_PROJECT_DIR}/files/pe-terminal/launch-pe-terminal.sh ${SNAPCRAFT_PART_INSTALL}/
+    organize:
+      bin/pe-terminal: wigwag/system/bin/pe-terminal
+  pe-utils:
+    plugin: nil
+    source: https://github.com/PelionIoT/pe-utils.git
+    source-tag: 2.3.0
+    override-build: |
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge/etc
+      install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/versions.json ${SNAPCRAFT_PART_INSTALL}/edge/
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
+      cp -r identity-tools ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils/
+      chmod -R 0755 ${SNAPCRAFT_PART_INSTALL}/wigwag/pe-utils
+      install -d ${SNAPCRAFT_PART_INSTALL}/bin/credentials
+      cp -r fw-tools/credentials/* ${SNAPCRAFT_PART_INSTALL}/bin/credentials
+      git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/pe-utils.VERSION"
+    stage-packages:
+      - gawk
+      - bc
+      - procps
+      - net-tools
+  edge-info:
+    plugin: dump
+    source: https://github.com/PelionIoT/pe-utils.git
+    source-tag: 2.3.0
+    override-build: |
+      install -d "${SNAPCRAFT_PART_INSTALL}/edge"
+      git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-info.VERSION"
+      snapcraftctl build
+    organize:
+      'edge-info/edge-info': bin/edge-info
+    stage-packages:
+      - gawk
+      - bc
+      - procps
+      - net-tools
+  edge-testnet:
+    plugin: dump
+    source: https://github.com/PelionIoT/pe-utils.git
+    source-tag: 2.3.0
+    override-build: |
+      install -d "${SNAPCRAFT_PART_INSTALL}/edge"
+      git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-testnet.VERSION"
+      snapcraftctl build
+    organize:
+      'fw-tools/edge-testnet': bin/edge-testnet
+      'fw-tools/credentials/bootstrap.pem': bin/credentials/bootstrap.pem
+      'fw-tools/credentials/device01_cert.pem': bin/credentials/device01_cert.pem
+      'fw-tools/credentials/device01_key.pem': bin/credentials/device01_key.pem
+      'fw-tools/credentials/lwm2m.pem': bin/credentials/lwm2m.pem
+    stage-packages:
+      - net-tools
+      - netcat-openbsd
+  yq:
+    plugin: go
+    build-environment:
+      - GOFLAGS: "$GOFLAGS -modcacherw"
+    source: https://github.com/mikefarah/yq.git
+    source-tag: 3.4.1
+  maestro:
+    plugin: make
+    source: https://github.com/PelionIoT/maestro.git
+    source-commit: v3.0.0
+    build-packages:
+      - libuv1-dev
+    build-environment:
+      - GOFLAGS: "$GOFLAGS -modcacherw"
+    override-build: |
+      # setup the go build environment
+      . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
+      gopartbootstrap github.com/PelionIoT/maestro
+      # Specify GOBIN so that maestro/build.sh doesn't do unexpected things
+      export GOBIN=${GOPATH}/bin
 
-    jq:
-      plugin: autotools
-      autotools-configure-parameters:
-        - -disable-docs
-      source: https://github.com/stedolan/jq.git
-      source-tag: jq-1.6
-      build-packages:
-        - libtool
-        - flex
-        - bison
-        - make
-        - automake
-        - autoconf
-        - openssl
-      stage-packages:
-        - jq
-      organize:
-        'jq': bin/jq
+      go build -o ${GOPATH}/bin/maestro maestro/main.go
 
-    curl:
-      plugin: autotools
-      source: https://github.com/curl/curl.git
-      source-tag: curl-8_0_1
-      autotools-configure-parameters:
+      # Install maestro components into the SNAPCRAFT_PART_INSTALL folder so that it is
+      # copied into the prime directory during the prime step
+      install ${SNAPCRAFT_PROJECT_DIR}/files/maestro/launch-maestro.sh ${SNAPCRAFT_PART_INSTALL}/
+
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates
+      install ${SNAPCRAFT_PROJECT_DIR}/files/maestro/config/maestro-config-dell5000.yaml ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates/
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
+      install ${GOPATH}/bin/maestro ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/maestro
+
+      # fixup the SNAP and SNAP_DATA variables in the config files based on the snap name
+      sed -i "s!/snap/pelion-edge!/snap/${SNAPCRAFT_PROJECT_NAME}!" ${SNAPCRAFT_PART_INSTALL}/wigwag/etc/templates/*.yaml
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge
+      git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/maestro.VERSION"
+    stage-packages:
+      - libuv1
+  fluent-bit:
+    plugin: cmake
+    source: https://github.com/fluent/fluent-bit.git
+    source-tag: v1.7.9
+    build-packages:
+      - libsystemd-dev
+      - flex
+      - bison
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=""
+      - -DFLB_JEMALLOC=On
+      - -DFLB_SHARED_LIB=Off
+      - -DFLB_EXAMPLES=Off
+      - -DFLB_IN_SYSTEMD=On
+    override-build: |
+      snapcraftctl build
+      install ${SNAPCRAFT_PROJECT_DIR}/files/fluent-bit/config/fluent-bit.conf ${SNAPCRAFT_PART_INSTALL}/
+      install ${SNAPCRAFT_PROJECT_DIR}/files/fluent-bit/scripts/launch-fluent-bit.sh ${SNAPCRAFT_PART_INSTALL}/
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge
+      git describe --tags --always > ${SNAPCRAFT_PART_INSTALL}/edge/fluent-bit.VERSION
+    organize:
+      bin/fluent-bit: wigwag/system/bin/fluent-bit
+  cni:
+    plugin: go
+    source: https://github.com/containernetworking/plugins.git
+    source-commit: 1f33fb729ae2b8900785f896df2dc1f6fe5e8239
+    override-build: |
+      export GOPATH=${SNAPCRAFT_PART_SRC}/../go
+
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/opt/cni/bin
+      PLUGINS="plugins/meta/* plugins/main/* plugins/ipam/*"
+      for d in $PLUGINS; do
+        echo "$d"
+        if [ -d "$d" ]; then
+          plugin="$(basename "$d")"
+          if [ $plugin != "windows" ]; then
+            echo "  cni/$plugin"
+            go install github.com/containernetworking/plugins/$d
+            # Build happens in parts/cni/build - use relative path to enable cross-compilation
+            install ../install/bin/$plugin ${SNAPCRAFT_PART_INSTALL}/wigwag/system/opt/cni/bin/$plugin
+          fi
+        fi
+      done
+
+      install -m 0755 ${SNAPCRAFT_PROJECT_DIR}/files/cni/c2d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/opt/cni/bin/c2d
+      install -m 0755 ${SNAPCRAFT_PROJECT_DIR}/files/cni/c2d-inner ${SNAPCRAFT_PART_INSTALL}/wigwag/system/opt/cni/bin/c2d-inner
+
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/etc/cni/net.d
+      install -m 0644 ${SNAPCRAFT_PROJECT_DIR}/files/cni/10-c2d.conf ${SNAPCRAFT_PART_INSTALL}/wigwag/system/etc/cni/net.d/10-c2d.conf
+      install -m 0644 ${SNAPCRAFT_PROJECT_DIR}/files/cni/99-loopback.conf ${SNAPCRAFT_PART_INSTALL}/wigwag/system/etc/cni/net.d/99-loopback.conf
+
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge
+      git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/cni.VERSION"
+  kubelet:
+    plugin: make
+    source: https://github.com/PelionIoT/edge-kubelet.git
+    source-commit: 35225842cd6b20d98613d8c1b08b7a376bd3209d
+    build-packages:
+      - libseccomp-dev
+    override-build: |
+      # setup the go build environment
+      . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
+      gopartbootstrap k8s.io/kubernetes
+
+      cd hack/make-rules
+      KUBE_VERBOSE=0 ./build.sh cmd/kubelet
+
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/var/lib/kubelet
+      install -d ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin
+      install -m 0644 ${SNAPCRAFT_PROJECT_DIR}/files/kubelet/config/kubeconfig ${SNAPCRAFT_PART_INSTALL}/wigwag/system/var/lib/kubelet/kubeconfig
+      install -m 0755 ${GOPATH}/src/k8s.io/kubernetes/_output/bin/kubelet ${SNAPCRAFT_PART_INSTALL}/wigwag/system/bin/kubelet
+      install ${SNAPCRAFT_PROJECT_DIR}/files/kubelet/scripts/launch-kubelet.sh ${SNAPCRAFT_PART_INSTALL}/
+      install ${SNAPCRAFT_PROJECT_DIR}/files/kubelet/scripts/launch-edgenet.sh ${SNAPCRAFT_PART_INSTALL}/
+
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge
+      git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/kubelet.VERSION"
+    stage:
+      - -usr/share/*
+    stage-packages: [systemd, util-linux]
+  jq:
+    plugin: autotools
+    autotools-configure-parameters:
+      - -disable-docs
+    source: https://github.com/stedolan/jq.git
+    source-tag: jq-1.6
+    build-packages:
+      - libtool
+      - flex
+      - bison
+      - make
+      - automake
+      - autoconf
+      - openssl
+    stage-packages:
+      - jq
+    organize:
+      'jq': bin/jq
+  curl:
+    plugin: autotools
+    source: https://github.com/curl/curl.git
+    source-tag: curl-8_0_1
+    autotools-configure-parameters:
       - --prefix=/
       - --with-openssl
-      build-packages:
-        # Curl build dependencies
-        - libssl-dev
-        - libssh-dev
-        - libzstd-dev
-        - libpsl-dev
-        # for build-in manual
-        - groff
-      stage-packages:
-        - libpsl5
-
-    docker-wrapper-scripts:
-      plugin: dump
-      source: files/docker/
-      # stage-packages:
-      # - mount
-      stage:
+    build-packages:
+      # Curl build dependencies
+      - libssl-dev
+      - libssh-dev
+      - libzstd-dev
+      - libpsl-dev
+      # for build-in manual
+      - groff
+    stage-packages:
+      - libpsl5
+  docker-wrapper-scripts:
+    plugin: dump
+    source: files/docker/
+    # stage-packages:
+    # - mount
+    stage:
       - bin/*
       - patches/*
       - config/daemon.json
-      prime:
+    prime:
       - -bin/prep-docker-build.sh
       - -patches/*
       - bin/*
       - config/daemon.json
+  docker-docker:
+    plugin: make
+    source: https://github.com/docker/docker-ce.git
+    source-tag: v18.06.1-ce
+    source-depth: 1
+    override-build: |
+      # docker build specific environment variables
+      export VERSION=$(cat VERSION)
+      export DOCKER_GITCOMMIT=$(git rev-parse --short HEAD)
+      export GITCOMMIT=$DOCKER_GITCOMMIT
+      export DISABLE_WARN_OUTSIDE_CONTAINER=1
 
-    docker-docker:
-      plugin: make
-      source: https://github.com/docker/docker-ce.git
-      source-tag: v18.06.1-ce
-      source-depth: 1
-      override-build: |
-        # docker build specific environment variables
-        export VERSION=$(cat VERSION)
-        export DOCKER_GITCOMMIT=$(git rev-parse --short HEAD)
-        export GITCOMMIT=$DOCKER_GITCOMMIT
-        export DISABLE_WARN_OUTSIDE_CONTAINER=1
+      # this patches the docker sources
+      . "$SNAPCRAFT_STAGE/bin/prep-docker-build.sh"
 
-        # this patches the docker sources
-        . "$SNAPCRAFT_STAGE/bin/prep-docker-build.sh"
+      # setup the go build environment for docker-ce
+      . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
+      gopartbootstrap github.com/docker/docker-ce
 
-        # setup the go build environment for docker-ce
-        . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
-        gopartbootstrap github.com/docker/docker-ce
+      # build the dockerd binary
+      cd components/engine
+      ./hack/make.sh dynbinary
+      cd $GOIMPORTPATH
 
-        # build the dockerd binary
-        cd components/engine
-        ./hack/make.sh dynbinary
-        cd $GOIMPORTPATH
+      unset LDFLAGS
+      ln -s "$(pwd)/components/cli" $GOPATH/src/github.com/docker/cli
+      make -C $GOPATH/src/github.com/docker/cli dynbinary
 
-        unset LDFLAGS
-        ln -s "$(pwd)/components/cli" $GOPATH/src/github.com/docker/cli
-        make -C $GOPATH/src/github.com/docker/cli dynbinary
-
-        install -d "$SNAPCRAFT_PART_INSTALL/bin"
-        install -T "$GOPATH/src/github.com/docker/cli/build/docker" "$SNAPCRAFT_PART_INSTALL/bin/docker"
-        install -T "$GOPATH/src/github.com/docker/docker-ce/components/engine/bundles/latest/dynbinary-daemon/dockerd" "$SNAPCRAFT_PART_INSTALL/bin/dockerd"
-        install -T "$GOPATH/src/github.com/docker/docker-ce/components/cli/contrib/completion/bash/docker" "$SNAPCRAFT_PART_INSTALL/bin/docker-completion.sh"
-      after:
+      install -d "$SNAPCRAFT_PART_INSTALL/bin"
+      install -T "$GOPATH/src/github.com/docker/cli/build/docker" "$SNAPCRAFT_PART_INSTALL/bin/docker"
+      install -T "$GOPATH/src/github.com/docker/docker-ce/components/engine/bundles/latest/dynbinary-daemon/dockerd" "$SNAPCRAFT_PART_INSTALL/bin/dockerd"
+      install -T "$GOPATH/src/github.com/docker/docker-ce/components/cli/contrib/completion/bash/docker" "$SNAPCRAFT_PART_INSTALL/bin/docker-completion.sh"
+    after:
       - docker-wrapper-scripts
-      build-packages:
+    build-packages:
       - gcc
       - libc6-dev
       - libdevmapper-dev
@@ -868,122 +833,116 @@ parts:
       - patch
       - git
       - pkg-config
-      stage-packages:
+    stage-packages:
       - zfsutils-linux
       - libltdl7
+  docker-containerd:
+    plugin: go
+    source: https://github.com/containerd/containerd.git
+    # from : https://github.com/docker/docker-ce/blob/v18.06.1-ce/components/engine/hack/dockerfile/install/containerd.installer
+    source-tag: v1.1.2
+    override-build: |
+      # setup the go build environment for containerd
+      . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
+      gopartbootstrap github.com/containerd/containerd
 
-    docker-containerd:
-      plugin: go
-      source: https://github.com/containerd/containerd.git
-      # from : https://github.com/docker/docker-ce/blob/v18.06.1-ce/components/engine/hack/dockerfile/install/containerd.installer
-      source-tag: v1.1.2
-      override-build: |
-        # setup the go build environment for containerd
-        . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
-        gopartbootstrap github.com/containerd/containerd
+      make GIT_COMMIT= GIT_BRANCH= LDFLAGS=
 
-        make GIT_COMMIT= GIT_BRANCH= LDFLAGS=
-
-        install -d "$SNAPCRAFT_PART_INSTALL/bin"
-        install -T bin/containerd "$SNAPCRAFT_PART_INSTALL/bin/docker-containerd"
-        install -T bin/containerd-shim "$SNAPCRAFT_PART_INSTALL/bin/docker-containerd-shim"
-        install -T bin/ctr "$SNAPCRAFT_PART_INSTALL/bin/docker-containerd-ctr"
-      after:
+      install -d "$SNAPCRAFT_PART_INSTALL/bin"
+      install -T bin/containerd "$SNAPCRAFT_PART_INSTALL/bin/docker-containerd"
+      install -T bin/containerd-shim "$SNAPCRAFT_PART_INSTALL/bin/docker-containerd-shim"
+      install -T bin/ctr "$SNAPCRAFT_PART_INSTALL/bin/docker-containerd-ctr"
+    after:
       - docker-wrapper-scripts
-      build-packages:
+    build-packages:
       - make
+  docker-runc:
+    plugin: make
+    source: https://github.com/opencontainers/runc.git
+    # from https://github.com/docker/docker-ce/blob/v18.06.1-ce/components/engine/hack/dockerfile/install/runc.installer
+    source-commit: 69663f0bd4b60df09991c08812a60108003fa340
+    override-build: |
+      # setup the go build environment for runc
+      . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
+      gopartbootstrap github.com/opencontainers/runc
 
-    docker-runc:
-      plugin: make
-      source: https://github.com/opencontainers/runc.git
-      # from https://github.com/docker/docker-ce/blob/v18.06.1-ce/components/engine/hack/dockerfile/install/runc.installer
-      source-commit: 69663f0bd4b60df09991c08812a60108003fa340
-      override-build: |
-        # setup the go build environment for runc
-        . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
-        gopartbootstrap github.com/opencontainers/runc
+      make BUILDTAGS='seccomp apparmor selinux' COMMIT=
 
-        make BUILDTAGS='seccomp apparmor selinux' COMMIT=
-
-        install -d "$SNAPCRAFT_PART_INSTALL/bin"
-        install -T runc "$SNAPCRAFT_PART_INSTALL/bin/docker-runc"
-      after:
+      install -d "$SNAPCRAFT_PART_INSTALL/bin"
+      install -T runc "$SNAPCRAFT_PART_INSTALL/bin/docker-runc"
+    after:
       - docker-wrapper-scripts
-      build-packages:
+    build-packages:
       - libapparmor-dev
       - libseccomp-dev
       - make
-
-    docker-libnetwork:
-      plugin: make
-      source: https://github.com/docker/libnetwork.git
-      # from https://github.com/docker/docker-ce/blob/v18.06.1-ce/components/engine/hack/dockerfile/install/proxy.installer
-      source-commit: 3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b
-      override-build: |
-        # setup the go build environment for libnetwork
-        . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
-        gopartbootstrap github.com/docker/libnetwork
-        make build-local
-        install -d "$SNAPCRAFT_PART_INSTALL/bin"
-        install -T bin/docker-proxy "$SNAPCRAFT_PART_INSTALL/bin/docker-proxy"
-        install -T bin/dnet "$SNAPCRAFT_PART_INSTALL/bin/dnet"
-      after:
+  docker-libnetwork:
+    plugin: make
+    source: https://github.com/docker/libnetwork.git
+    # from https://github.com/docker/docker-ce/blob/v18.06.1-ce/components/engine/hack/dockerfile/install/proxy.installer
+    source-commit: 3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b
+    override-build: |
+      # setup the go build environment for libnetwork
+      . ${SNAPCRAFT_PROJECT_DIR}/files/docker/bin/go-build-helper.sh
+      gopartbootstrap github.com/docker/libnetwork
+      make build-local
+      install -d "$SNAPCRAFT_PART_INSTALL/bin"
+      install -T bin/docker-proxy "$SNAPCRAFT_PART_INSTALL/bin/docker-proxy"
+      install -T bin/dnet "$SNAPCRAFT_PART_INSTALL/bin/dnet"
+    after:
       - docker-wrapper-scripts
-      build-packages:
+    build-packages:
       - iptables
       - make
-
-    docker-tini:
-      plugin: cmake
-      # core18 uses a a default prefix, core20 and core22 do not
-      cmake-parameters:
-        - -DCMAKE_INSTALL_PREFIX=""
-      source: https://github.com/krallin/tini.git
-      source-type: git
-      # from https://github.com/docker/docker-ce/blob/v19.03.12/components/engine/hack/dockerfile/install/tini.installer
-      source-tag: v0.18.0
-      organize:
-        'bin/tini-static': bin/docker-init
-      prime:
-        - bin/tini
-        - bin/docker-init
-      build-packages:
+  docker-tini:
+    plugin: cmake
+    # core18 uses a a default prefix, core20 and core22 do not
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=""
+    source: https://github.com/krallin/tini.git
+    source-type: git
+    # from https://github.com/docker/docker-ce/blob/v19.03.12/components/engine/hack/dockerfile/install/tini.installer
+    source-tag: v0.18.0
+    organize:
+      'bin/tini-static': bin/docker-init
+    prime:
+      - bin/tini
+      - bin/docker-init
+    build-packages:
       - build-essential
-
-    cosign:
-      plugin: go
-      source: https://github.com/sigstore/cosign.git
-      source-commit: v1.13.1
-      build-environment:
-        - GOFLAGS: "$GOFLAGS -modcacherw"
-      override-build: |
-        export ALT_GO=go1.18
-        export ORI_GO=go1.15
-        export GOROOT=/usr/local/$ALT_GO
-        export PATH="$GOROOT/bin:$PATH"
-        echo Hacking/changing the go version to $ALT_GO
-        sudo rm /usr/local/bin/go /usr/local/bin/gofmt
-        sudo ln -sf "/usr/local/$ALT_GO/bin/go" /usr/local/bin/go
-        sudo ln -sf "/usr/local/$ALT_GO/bin/gofmt" /usr/local/bin/gofmt
-        snapcraftctl build
-        echo Reverting the go version to $ORI_GO
-        sudo rm /usr/local/bin/go /usr/local/bin/gofmt
-        sudo ln -sf "/usr/local/$ORI_GO/bin/go" /usr/local/bin/go
-        sudo ln -sf "/usr/local/$ORI_GO/bin/gofmt" /usr/local/bin/gofmt
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge
-        git describe --tags --always > "${SNAPCRAFT_PART_INSTALL}/edge/cosign.VERSION"
-      stage:
-        - -bin/help
-
-    bouncer:
-      plugin: cmake
-      cmake-parameters:
-        - -DCMAKE_INSTALL_PREFIX=""
-      source: https://github.com/PelionIoT/bouncer.git
-      source-type: git
-      source-tag: v1.1.0
-      override-build: |
-        snapcraftctl build
-        install ${SNAPCRAFT_PROJECT_DIR}/files/bouncer/scripts/launch-bouncer.sh ${SNAPCRAFT_PART_INSTALL}/
-        install -d ${SNAPCRAFT_PART_INSTALL}/edge
-        git -C ${SNAPCRAFT_PART_SRC} describe --tags >"${SNAPCRAFT_PART_INSTALL}/edge/bouncer.VERSION"
+  cosign:
+    plugin: go
+    source: https://github.com/sigstore/cosign.git
+    source-commit: v1.13.1
+    build-environment:
+      - GOFLAGS: "$GOFLAGS -modcacherw"
+    override-build: |
+      export ALT_GO=go1.18
+      export ORI_GO=go1.15
+      export GOROOT=/usr/local/$ALT_GO
+      export PATH="$GOROOT/bin:$PATH"
+      echo Hacking/changing the go version to $ALT_GO
+      sudo rm /usr/local/bin/go /usr/local/bin/gofmt
+      sudo ln -sf "/usr/local/$ALT_GO/bin/go" /usr/local/bin/go
+      sudo ln -sf "/usr/local/$ALT_GO/bin/gofmt" /usr/local/bin/gofmt
+      snapcraftctl build
+      echo Reverting the go version to $ORI_GO
+      sudo rm /usr/local/bin/go /usr/local/bin/gofmt
+      sudo ln -sf "/usr/local/$ORI_GO/bin/go" /usr/local/bin/go
+      sudo ln -sf "/usr/local/$ORI_GO/bin/gofmt" /usr/local/bin/gofmt
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge
+      git describe --tags --always > "${SNAPCRAFT_PART_INSTALL}/edge/cosign.VERSION"
+    stage:
+      - -bin/help
+  bouncer:
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=""
+    source: https://github.com/PelionIoT/bouncer.git
+    source-type: git
+    source-tag: v1.1.0
+    override-build: |
+      snapcraftctl build
+      install ${SNAPCRAFT_PROJECT_DIR}/files/bouncer/scripts/launch-bouncer.sh ${SNAPCRAFT_PART_INSTALL}/
+      install -d ${SNAPCRAFT_PART_INSTALL}/edge
+      git -C ${SNAPCRAFT_PART_SRC} describe --tags >"${SNAPCRAFT_PART_INSTALL}/edge/bouncer.VERSION"


### PR DESCRIPTION
The contents should be exactly the same, we're just rolling it through `yq` to make it normalise the content. This makes future `yq` operations more friendly for diffing.

Beyond Compare works well for spotting any content changes.