### PR TITLE
snapcraft.yaml - upgrade curl to 8.5.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -763,7 +763,7 @@ parts:
   curl:
     plugin: autotools
     source: https://github.com/curl/curl.git
-    source-tag: curl-8_0_1
+    source-tag: curl-8_5_0
     autotools-configure-parameters:
       - --prefix=/
       - --with-openssl


### PR DESCRIPTION
Update `curl` to latest version.
We have `curl` as a separate package, it's there as `pelion-edge.curl`.
Edge-core itself is using the linked one that gets pulled via cmakefiles.
