### PR TITLE
Update pe-utils, edge-testnet, edge-info to v2.3.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -576,7 +576,7 @@ parts:
   pe-utils:
     plugin: nil
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.0
+    source-tag: 2.3.1
     override-build: |
       install -d ${SNAPCRAFT_PART_INSTALL}/edge/etc
       install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/versions.json ${SNAPCRAFT_PART_INSTALL}/edge/
@@ -595,7 +595,7 @@ parts:
   edge-info:
     plugin: dump
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.0
+    source-tag: 2.3.1
     override-build: |
       install -d "${SNAPCRAFT_PART_INSTALL}/edge"
       git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-info.VERSION"
@@ -610,7 +610,7 @@ parts:
   edge-testnet:
     plugin: dump
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.0
+    source-tag: 2.3.1
     override-build: |
       install -d "${SNAPCRAFT_PART_INSTALL}/edge"
       git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-testnet.VERSION"


### PR DESCRIPTION
* Update the pe-utils to latest.
* This brings in the edge-info `echo $NORM` -bug.
* Add also an action to confirm the versions stay aligned between pe-utils, edge-info and edge-testnet.
