### PR TITLE
pe-utils 2.3.5 upgrade, no timeout on build job, -y to apt install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
     runs-on: client
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get install black pycodestyle pydocstyle shellcheck python3
+      - run: sudo apt-get install -y black pycodestyle pydocstyle shellcheck python3
       - name: Check out scripts-internal
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ concurrency:
 
 jobs:
   build-snap:
-    runs-on: [ "snap" ]
-    timeout-minutes: 40
+    runs-on: [ "self-hosted", "snap" ]
     steps:
       - name: Enable write on all files
         run:  chmod a+w -R .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -577,7 +577,7 @@ parts:
   pe-utils:
     plugin: nil
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.4
+    source-tag: 2.3.5
     override-build: |
       install -d ${SNAPCRAFT_PART_INSTALL}/edge/etc
       install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/versions.json ${SNAPCRAFT_PART_INSTALL}/edge/
@@ -596,7 +596,7 @@ parts:
   edge-info:
     plugin: dump
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.4
+    source-tag: 2.3.5
     override-build: |
       install -d "${SNAPCRAFT_PART_INSTALL}/edge"
       git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-info.VERSION"
@@ -611,7 +611,7 @@ parts:
   edge-testnet:
     plugin: dump
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.4
+    source-tag: 2.3.5
     override-build: |
       install -d "${SNAPCRAFT_PART_INSTALL}/edge"
       git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-testnet.VERSION"


### PR DESCRIPTION
Abandoned the effort to run on client-runners, the only way a container can run the docker is if they are privileged and we do not want that. Only one runner with that capability for the snaps and that's it.

Keep the more generic changes.
* Update pe-utils to 2.3.5 (latest).
* Add the missing -y to the sudo apt install.
* Remove timeout (if our self-hosted machine is too loaded, the build can take >40 minutes).
    * This happened when all client-runners were VMs, now that they are again containers this should not happen again.
    * Normal build time is around 20 minutes give or take.


Ready for review @petedyerarm  @jenia81, misleading label fixed.

