### PR TITLE
Remove .gitconfig from access token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
           path: "./*.log"
               
   yamllint-snapcraft-yaml:
-    runs-on: client
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get install yamllint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,9 @@ jobs:
 #        with:
 #          files: |
 #           results.xml
+      - name: Clean up .gitconfig
+        if: always()
+        run: rm -f ~/.gitconfig
 
   pysh-check:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build-snap:
-    runs-on: [ "self-hosted", "snap" ]
+    runs-on: [ "snap" ]
     timeout-minutes: 40
     steps:
       - name: Enable write on all files
@@ -165,7 +165,7 @@ jobs:
         run: rm -f ~/.gitconfig
 
   pysh-check:
-    runs-on: ubuntu-22.04
+    runs-on: client
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get install black pycodestyle pydocstyle shellcheck python3
@@ -187,7 +187,7 @@ jobs:
           path: "./*.log"
               
   yamllint-snapcraft-yaml:
-    runs-on: ubuntu-22.04
+    runs-on: client
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get install yamllint


### PR DESCRIPTION
One step uses the access token via git config redirect. It uses it to git clone 2 internal repos. Clean up after it.

NOTE! Required changnig the runner to a VM. Seems the container-in-a-container or something is not working correctly with the containers in Incus.


