### PR TITLE
Update pe-utils to 2.3.7

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -577,7 +577,7 @@ parts:
   pe-utils:
     plugin: nil
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.5
+    source-tag: 2.3.7
     override-build: |
       install -d ${SNAPCRAFT_PART_INSTALL}/edge/etc
       install ${SNAPCRAFT_PROJECT_DIR}/files/pe-utils/versions.json ${SNAPCRAFT_PART_INSTALL}/edge/
@@ -596,7 +596,7 @@ parts:
   edge-info:
     plugin: dump
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.5
+    source-tag: 2.3.7
     override-build: |
       install -d "${SNAPCRAFT_PART_INSTALL}/edge"
       git describe --tags --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-info.VERSION"
@@ -611,7 +611,7 @@ parts:
   edge-testnet:
     plugin: dump
     source: https://github.com/PelionIoT/pe-utils.git
-    source-tag: 2.3.5
+    source-tag: 2.3.7
     override-build: |
       install -d "${SNAPCRAFT_PART_INSTALL}/edge"
       git describe --tags  --always >"${SNAPCRAFT_PART_INSTALL}/edge/edge-testnet.VERSION"


### PR DESCRIPTION
Latest release: https://github.com/PelionIoT/pe-utils/releases/tag/2.3.7
- includes also of course changes from 2.3.6, which we didn't update in yet.