### PR TITLE
Update edge-proxy (1.4.0) and pe-terminanal (1.2.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG RISK=stable
 ARG UBUNTU=20.04
-ARG http_proxy=""
-ARG https_proxy=""
+#ARG http_proxy=""
+#ARG https_proxy=""
 # Based on Docker image at;
 # https://raw.githubusercontent.com/snapcore/snapcraft/master/docker/Dockerfile
 # Update to focal + merged in what we had originally here.
@@ -11,13 +11,13 @@ ARG https_proxy=""
 # ARG https_proxy="https://<user>:<password>@<proxy-ip>:<proxy-port>"
 
 # Use the proxy from docker build for the container runtime environment as well
-FROM ubuntu:$UBUNTU as builder
+FROM ubuntu:$UBUNTU AS builder
 ARG RISK
 ARG UBUNTU
 RUN echo "Building snapcraft:$RISK in ubuntu:$UBUNTU"
 
-ENV http_proxy=$http_proxy
-ENV https_proxy=$https_proxy
+ENV http_proxy=""
+ENV https_proxy=""
 
 # Grab dependencies
 RUN apt-get update
@@ -125,6 +125,8 @@ RUN curl -L https://dl.google.com/go/go1.15.15.linux-amd64.tar.gz | tar -xz && \
 
 RUN curl -L https://golang.org/dl/go1.18.10.linux-amd64.tar.gz | tar -xz && \
     mv go /usr/local/go1.18
+RUN curl -L https://golang.org/dl/go1.20.14.linux-amd64.tar.gz | tar -xz && \
+    mv go /usr/local/go1.20
 
 # Install the script that sets up the user environment
 # and runs CMD as the current user instead of as root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 ARG RISK=stable
 ARG UBUNTU=20.04
-#ARG http_proxy=""
-#ARG https_proxy=""
 # Based on Docker image at;
 # https://raw.githubusercontent.com/snapcore/snapcraft/master/docker/Dockerfile
 # Update to focal + merged in what we had originally here.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -515,11 +515,11 @@ parts:
   edge-proxy:
     plugin: go
     source: https://github.com/PelionIoT/edge-proxy.git
-    source-tag: v1.3.0
+    source-tag: v1.4.0
     build-environment:
       - GOFLAGS: "$GOFLAGS -modcacherw"
     override-build: |
-      export ALT_GO=go1.18
+      export ALT_GO=go1.20
       export ORI_GO=go1.15
       export GOROOT=/usr/local/$ALT_GO
       export PATH="$GOROOT/bin:$PATH"
@@ -545,11 +545,11 @@ parts:
   pe-terminal:
     plugin: go
     source: https://github.com/PelionIoT/pe-terminal.git
-    source-tag: v1.1.0
+    source-tag: v1.2.0
     build-environment:
       - GOFLAGS: "$GOFLAGS -modcacherw"
     override-build: |
-      export ALT_GO=go1.18
+      export ALT_GO=go1.20
       export ORI_GO=go1.15
       export GOROOT=/usr/local/$ALT_GO
       export PATH="$GOROOT/bin:$PATH"


### PR DESCRIPTION
Update edge-proxy and pe-terminal (aka edge-terminal) to the latest versions.

This requires then changes to `Dockerfile`:

Version 27.03 of `docker` does not seem to take the line 3 and 4 in anymore as previously, it ignores them. This made the build fail

```
 2 warnings found (use --debug to expand):
 - UndefinedVar: Usage of undefined variable '$http_proxy' (line 19)
 - UndefinedVar: Usage of undefined variable '$https_proxy' (line 20)
```

We also had one mixed capital usage with `FROM` and `as` -> `AS` needs to be in capital as well.

Install `golang 1.20` as it's needed with updated `pe-terminal` and `edge-proxy` - they are golang 1.20 based instead of 1.18.

